### PR TITLE
Add missing `BEGIN` and `END` to `slf_sized_stack`

### DIFF
--- a/src/examples/slf_sized_stack.c
+++ b/src/examples/slf_sized_stack.c
@@ -59,10 +59,12 @@ unsigned int sizeOf (struct sized_stack *p)
 
 void push (struct sized_stack *p, int x)
 /* FILL IN HERE */
+/* ---BEGIN--- */
 /*@ requires take S = SizedStack(p)
     ensures take S_ = SizedStack(p);
             S_.d == Seq_Cons {head:x, tail:S.d}
 @*/
+/* ---END--- */
 {
   struct int_list *data = IntList_cons(x, p->data);
   p->size++;


### PR DESCRIPTION
Since it says, `FILL IN HERE` for `push`'s specification.
I assume it was meant to have the specification excluded from the exercise.