### PR TITLE
change to usr/bin/env

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$1" ]
 then

--- a/src/example-archive/check.sh
+++ b/src/example-archive/check.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 if [ -n "$1" ]
 then


### PR DESCRIPTION
As far as I know `/usr/bin/env` is the more common location for `bash` and recommended for portability. 

By default OSX  has `/usr/bin/env` and does not have `bin/env` or a symbolic link from `/bin/env`. After 9bead3f8c78da1c56b8e9e16e3fb20b053d3c4d4 calling `src/example-archive/check.sh` will fail with

```
/bin/env: bad interpreter: No such file or directory
```
