### PR TITLE
Skip testing solutions if CN is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,12 @@ build/exercises/%: src/examples/%
 	@sed -E '\|^.*--BEGIN--.*$$|,\|^.*--END--.*$$|d' $< > $@
 
 build/solutions/%: src/examples/%
-	@if [[ "$<" = *".c"* ]]; then \
-	  if [[ "$<" != *"broken"* ]]; then \
-	     echo cn $< && cn $<; \
-	  fi; \
+	@if [ $(which cn) ]; then \
+	  if [[ "$<" = *".c"* ]]; then \
+	    if [[ "$<" != *"broken"* ]]; then \
+	       echo cn $< && cn $<; \
+	    fi; \
+	  fi \
 	fi
 #	cat $< | sed '/^--BEGIN--$$/d' | sed '/^--END--$$/d' > $@
 	@echo Rebuild $@


### PR DESCRIPTION
Running `make` without CN installed fails before building the tutorial.

This doesn't matter if we host the tutorial elsewhere, but we've been pointing new users to this repo to see the tutorial.  The tutorial contains instructions on how to install CN, so installing CN shouldn't be a prerequisite to building the tutorial.

With this change, `make` skips testing the example solutions if CN is not installed.