### PR TITLE
Clarify confusing parts of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CN-tutorial
 
+In order to build the tutorial, you will first need to install [asciidoctor](https://asciidoctor.org/).
+
 Run `make` to produce `build/tutorial.html` and its dependencies: especially, `build/exercises/*.c` and `build/solutions/*c`.
 
-Run `./check.sh` to check that all examples have working solutions (except tests with names `*.error.c`, which are expected to fail).
+Run `./check.sh` to check that all examples have working solutions (except tests with names `*.error.c`, which are expected to fail). Note that this step will not work until after you have installed CN, which is the first part of the tutorial.


### PR DESCRIPTION
I had trouble getting started because the README didn't mention a missing dependency on my computer, and it wasn't clear to me that the `./check.sh` step could only be run after CN is actually installed, AKA after I have started the tutorial.