### PR TITLE
Add GH action that deploys the tutorial to Pages

### DIFF
--- a/.github/workflows/deploy-to-web.yml
+++ b/.github/workflows/deploy-to-web.yml
@@ -1,0 +1,49 @@
+name: Deploy the CN tutorial to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7' 
+
+      - name: Install AsciiDoctor
+        run: gem install asciidoctor
+
+      - name: Clean and build the tutorial
+        run: |
+          rm -rf build/* 
+          make 
+          mv build/tutorial.html build/index.html  
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './build'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR adds a GH Action that deploys the tutorial to GitHub Pages. The tutorial should be hosted publicly at `https://rems-project.github.io/cn-tutorial/`, and it will be redeployed on every change pushed to the repo. 

Once the PR is merged to `main`, someone with admin rights will need to activate it as follows:  
1. Navigate to Settings > Pages.
2. In the "Source" section, select the GitHub Actions workflow option.

I've tested this PR on a fork - see [here](https://septract.github.io/cn-tutorial-web/). 

Addresses https://github.com/GaloisInc/VERSE-Toolchain/issues/95
