### PR TITLE
Enable section anchors

### DIFF
--- a/src/tutorial.adoc
+++ b/src/tutorial.adoc
@@ -3,6 +3,7 @@
 // :pygments-style: tango
 :nofooter:
 :prewrap!:
+:sectanchors:
 
 ++++
 <style>


### PR DESCRIPTION
Hovering over section titles now shows an anchor icon, which exposes a link to the section.  This is useful for highlighting and sharing pointers to particular parts of the tutorial.

![Screenshot 2024-06-06 at 9 29 32 AM](https://github.com/rems-project/cn-tutorial/assets/63367934/62acb3a3-f98e-43f0-b6d8-4e90d70d4ab7)
