### PR TITLE
Show failed tests and consider non-0 exit codes as failure.

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -10,6 +10,7 @@ fi
 
 good=0
 bad=0
+declare -a bad_tests
 
 for file in src/examples/*c;
 do
@@ -18,10 +19,11 @@ do
     retval=$?
     if [[ $file == *.broken.c ]]
     then
-        if [[ $retval -eq 1 ]]; 
+        if [[ $retval -ne 0 ]]; 
         then
             good=$(($good+1))
         else
+            bad_tests[$bad]=$file
             bad=$(($bad+1))
         fi
     else
@@ -29,6 +31,7 @@ do
         then
             good=$(($good+1))
         else
+            bad_tests[$bad]=$file
             bad=$(($bad+1))
         fi
     fi
@@ -43,6 +46,10 @@ if [[ "$bad" = 0 ]]
 then
   exit 0
 else
+  echo "Failed tests:"
+  for file in ${bad_tests[@]}; do
+    echo $file
+  done
   exit 1
 fi
 


### PR DESCRIPTION
Adds an array to track which files have failed, and considers all non-0 exit codes to be failure,
as on some examples `cn` returns exit code 2  (the script only considers 1 to be failure for bad examples).