### PR TITLE
Automatically build a dump of SMT output from recently changed files  

### DIFF
--- a/build-smt-log.sh
+++ b/build-smt-log.sh
@@ -9,7 +9,7 @@ then
     echo "using CN=$1 in $PWD"
     CN="$1"
 else
-    CN="cn"
+    CN="cn verify"
 fi
 
 # Generate a list of recently-changed files 
@@ -28,6 +28,7 @@ TEMP_DIR=$(realpath "$(mktemp -d ./tmp.XXXXXX)")
 # Create a log file listing the locations of SMT logs 
 DATE_STRING=$(date +"%Y-%m-%d_%H-%M-%S")
 echo "# Log date: $DATE_STRING" >> "$TEMP_DIR/manifest.md"
+echo "# $(cn --version)" >> "$TEMP_DIR/manifest.md"
 echo "" >> "$TEMP_DIR/manifest.md"
 
 ROOT_DIR=$(pwd)
@@ -42,17 +43,19 @@ for FILEPATH in $FILTERED_FILES; do
 
     cd $DIR 
     # Run CN on the target file 
-    $CN "$FILE" --solver-type=cvc5 --solver-logging="$LOG_DIR"
+    $CN "$FILE" --solver-type=cvc5 --solver-logging="$LOG_DIR"  1>&2
     cp "$FILE" "$LOG_DIR"
     cd "$ROOT_DIR"
 
     # Record the file in the manifest 
-    echo "$FILEPATH-log/" >> "$TEMP_DIR/manifest.md"
+    echo "$FILEPATH-log/" >> "$TEMP_DIR/manifest.md" 
   fi 
 done 
 
 # Create a zip file of the SMT logs 
 cd "$TEMP_DIR"
-zip -r "$ROOT_DIR/SMT-log-$DATE_STRING.zip" * 
+zip -r "$ROOT_DIR/SMT-log-$DATE_STRING.zip" *  1>&2 
 
 rm -r "$TEMP_DIR"
+
+echo "$ROOT_DIR/SMT-log-$DATE_STRING.zip"

--- a/build-smt-log.sh
+++ b/build-smt-log.sh
@@ -3,6 +3,7 @@
 BRANCH="main"
 INTERVAL="1.month"
 
+# Allow the CI process to pass a location for CN 
 if [ -n "$1" ]
 then
     echo "using CN=$1 in $PWD"
@@ -11,43 +12,47 @@ else
     CN="cn"
 fi
 
-EXAMPLE_RXP="^src/(examples/[^/]+\.c|example-archive/[^/]+/working/[^/]+\.c)$"
-FILTER_RXP="broken\.c$"
-
+# Generate a list of recently-changed files 
 FILES=$(git log --since="$INTERVAL" --name-only --pretty=format: "$BRANCH" | sort | uniq)
+
+# Regexp selecting files in the correct location 
+EXAMPLE_RXP="^src/(examples/[^/]+\.c|example-archive/[^/]+/working/[^/]+\.c)$"
+# Regexp filtering files marked broken 
+FILTER_RXP="broken\.c$"
+# Filter the list for files of interest 
 FILTERED_FILES=$(echo "$FILES" | grep -E "$EXAMPLE_RXP" | grep -Ev "$FILTER_RXP")
 
+# Create a temporary directory 
 TEMP_DIR=$(realpath "$(mktemp -d ./tmp.XXXXXX)")
+
+# Create a log file listing the locations of SMT logs 
+DATE_STRING=$(date +"%Y-%m-%d_%H-%M-%S")
+echo "# Log date: $DATE_STRING" >> "$TEMP_DIR/manifest.md"
+echo "" >> "$TEMP_DIR/manifest.md"
+
 ROOT_DIR=$(pwd)
-
-LOGGED_FILES=""
-
 for FILEPATH in $FILTERED_FILES; do 
   if [ -f "$FILEPATH" ]; then
     DIR=$(dirname "$FILEPATH")
     FILE=$(basename "$FILEPATH")
 
+    # Create the log directory for each file 
     LOG_DIR="$TEMP_DIR/$FILEPATH-log"
     mkdir -p "$LOG_DIR"
 
     cd $DIR 
+    # Run CN on the target file 
     $CN "$FILE" --solver-type=cvc5 --solver-logging="$LOG_DIR"
     cp "$FILE" "$LOG_DIR"
     cd "$ROOT_DIR"
 
-    LOGGED_FILES="$LOGGED_FILES $FILEPATH-log/" 
+    # Record the file in the manifest 
+    echo "$FILEPATH-log/" >> "$TEMP_DIR/manifest.md"
   fi 
 done 
 
-DATE_STRING=$(date +"%Y-%m-%d_%H-%M-%S")
-echo "Log date: $DATE_STRING" >> "$TEMP_DIR/manifest.txt"
-echo "" >> "$TEMP_DIR/manifest.txt"
-
-for FILE in $LOGGED_FILES; do 
-  echo "$FILE" >> "$TEMP_DIR/manifest.txt"
-done 
-
+# Create a zip file of the SMT logs 
 cd "$TEMP_DIR"
-zip -r "$ROOT_DIR/SMT-log-$DATE_STRING.zip" ./* 
+zip -r "$ROOT_DIR/SMT-log-$DATE_STRING.zip" * 
 
 rm -r "$TEMP_DIR"

--- a/build-smt-log.sh
+++ b/build-smt-log.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash 
+
+BRANCH="main"
+INTERVAL="1.month"
+
+if [ -n "$1" ]
+then
+    echo "using CN=$1 in $PWD"
+    CN="$1"
+else
+    CN="cn"
+fi
+
+EXAMPLE_RXP="^src/(examples/[^/]+\.c|example-archive/[^/]+/working/[^/]+\.c)$"
+FILTER_RXP="broken\.c$"
+
+FILES=$(git log --since="$INTERVAL" --name-only --pretty=format: "$BRANCH" | sort | uniq)
+FILTERED_FILES=$(echo "$FILES" | grep -E "$EXAMPLE_RXP" | grep -Ev "$FILTER_RXP")
+
+TEMP_DIR=$(realpath "$(mktemp -d ./tmp.XXXXXX)")
+ROOT_DIR=$(pwd)
+
+LOGGED_FILES=""
+
+for FILEPATH in $FILTERED_FILES; do 
+  if [ -f "$FILEPATH" ]; then
+    DIR=$(dirname "$FILEPATH")
+    FILE=$(basename "$FILEPATH")
+
+    LOG_DIR="$TEMP_DIR/$FILEPATH-log"
+    mkdir -p "$LOG_DIR"
+
+    cd $DIR 
+    $CN "$FILE" --solver-type=cvc5 --solver-logging="$LOG_DIR"
+    cp "$FILE" "$LOG_DIR"
+    cd "$ROOT_DIR"
+
+    LOGGED_FILES="$LOGGED_FILES $FILEPATH-log/" 
+  fi 
+done 
+
+DATE_STRING=$(date +"%Y-%m-%d_%H-%M-%S")
+echo "Log date: $DATE_STRING" >> "$TEMP_DIR/manifest.txt"
+echo "" >> "$TEMP_DIR/manifest.txt"
+
+for FILE in $LOGGED_FILES; do 
+  echo "$FILE" >> "$TEMP_DIR/manifest.txt"
+done 
+
+cd "$TEMP_DIR"
+zip -r "$ROOT_DIR/SMT-log-$DATE_STRING.zip" ./* 
+
+rm -r "$TEMP_DIR"


### PR DESCRIPTION
We want to generate regular SMT data dumps from CN to support the Stanford team. This PR adds a script that dumps SMT output from recently changed files, and wraps it in a zip / tar.gz file. 

The script uses `git log` to figure out what files have changed in the last month.