### PR TITLE
Install pygments gem during web deployment

### DIFF
--- a/.github/workflows/deploy-to-web.yml
+++ b/.github/workflows/deploy-to-web.yml
@@ -28,7 +28,7 @@ jobs:
           ruby-version: '2.7' 
 
       - name: Install AsciiDoctor
-        run: gem install asciidoctor
+        run: gem install asciidoctor pygments.rb
 
       - name: Clean the build directory 
         run: rm -rf build/* 


### PR DESCRIPTION
Though my local build of the tutorial has C syntax highlighting, the deployed version does not. Looking at the logs of a [recent deployment](https://github.com/rems-project/cn-tutorial/actions/runs/10041798272/job/27750695616), I see the following:
```
<...>
Create build/tutorial.adoc
cp -r src/images build/images
asciidoctor --doctype book build/tutorial.adoc -o build/tutorial.html
asciidoctor: WARNING: optional gem 'pygments.rb' is not available (reason: cannot load 'pygments'). Functionality disabled.
cd build; zip -r exercises.zip exercises > /dev/null
```

I tried making this change and running the publishing workflow on my own fork, and it worked there, so I certainly hope it will work here as well.