### PR TITLE
Use `cn verify` in `check.sh`

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 if [ -n "$1" ]
 then
     echo "using CN=$1 in $PWD"
-    CN="$1"
+    CN="$1 verify"
 else
     CN=cn verify
 fi


### PR DESCRIPTION
The `make check-tutorial` and `make check` commands were not working because the command passed from the `Makefile` to the `check.sh` script was only `cn`, which did not include the necessary `verify` argument.  This change makes the commands run as expected.