### PR TITLE
Fix IntListSeg predicate

### DIFF
--- a/src/example-archive/simple-examples/working/list_preds.h
+++ b/src/example-archive/simple-examples/working/list_preds.h
@@ -25,11 +25,10 @@ datatype seq {
 
 /*@
 predicate (datatype seq) IntListSeg(pointer p, pointer tail) {
-  if (addr_eq(p,tail)) {
+  if (ptr_eq(p,tail)) {
     return Seq_Nil{};
   } else {
     take H = Owned<struct list_node>(p);
-    assert (is_null(H.next) || H.next != NULL);
     take tl = IntListSeg(H.next, tail);
     return (Seq_Cons { val: H.val, next: tl });
   }


### PR DESCRIPTION
https://github.com/rems-project/cerberus/pull/494 made this tests fail, but it wasn't quite phrased correctly anyways. It may need further changes for more VIP features later, but this should suffice for now.