### PR TITLE
Fix CI to use Cerberus deps

### DIFF
--- a/.github/workflows/run-cn-examples.yml
+++ b/.github/workflows/run-cn-examples.yml
@@ -37,22 +37,12 @@ jobs:
         path: ~/.opam
         key: ${{ matrix.version }}
 
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+    - name: Setup opam and install dependencies
       run: |
         opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
-        opam install --deps-only --yes ./cerberus-lib.opam
-        opam switch create with_coq ${{ matrix.version }}
-        eval $(opam env --switch=with_coq)
-        opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
-        opam repo add --yes --this-switch iris-dev https://gitlab.mpi-sws.org/iris/opam.git
-        opam pin --yes -n coq-sail-stdpp https://github.com/rems-project/coq-sail.git#f319aad
-        opam pin --yes -n coq-cheri-capabilities https://github.com/rems-project/coq-cheri-capabilities.git
-        opam install --deps-only --yes ./cerberus-lib.opam ./cerberus-cheri.opam
+        opam install --deps-only --yes ./cerberus.opam ./cerberus-lib.opam ./cn.opam
     
     - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       id: cache-opam-save
       uses: actions/cache/save@v4
       with:


### PR DESCRIPTION
CI broke because the build script pins specific versions of Cerberus dependencies, which Cerberus has since changed.

The solution is to use the Cerberus dependency requirements in its OPAM files when building CN in CI.