### PR TITLE
Record all output for tests

### DIFF
--- a/cvc5.json
+++ b/cvc5.json
@@ -1,0 +1,6 @@
+{
+    "name": "cvc5",
+    "args": ["verify", "--solver-type=cvc5"],
+    "filter": "^(.*\\.c)$",
+    "timeout": 60
+}

--- a/src/example-archive/Rust/broken/error-cerberus/00002-memory-leaks.c.cvc5
+++ b/src/example-archive/Rust/broken/error-cerberus/00002-memory-leaks.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/Rust/broken/error-cerberus/00002-memory-leaks.c.z3
+++ b/src/example-archive/Rust/broken/error-cerberus/00002-memory-leaks.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/Rust/broken/error-cerberus/00003-string-transfer.c.cvc5
+++ b/src/example-archive/Rust/broken/error-cerberus/00003-string-transfer.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/Rust/broken/error-cerberus/00003-string-transfer.c.z3
+++ b/src/example-archive/Rust/broken/error-cerberus/00003-string-transfer.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/Rust/broken/error-cerberus/00005-lifetimes.c.cvc5
+++ b/src/example-archive/Rust/broken/error-cerberus/00005-lifetimes.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/Rust/broken/error-cerberus/00005-lifetimes.c.z3
+++ b/src/example-archive/Rust/broken/error-cerberus/00005-lifetimes.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/Rust/broken/error-proof/00001-memory-leaks-no-print.c.cvc5
+++ b/src/example-archive/Rust/broken/error-proof/00001-memory-leaks-no-print.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00001-memory-leaks-no-print.c:29:18: error: Unknown function 'malloc_proxy'
+  int *my_data = malloc(sizeof(int)); // Allocate memory for an integer on the heap
+                 ^~~~~~ 

--- a/src/example-archive/Rust/broken/error-proof/00001-memory-leaks-no-print.c.z3
+++ b/src/example-archive/Rust/broken/error-proof/00001-memory-leaks-no-print.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00001-memory-leaks-no-print.c:29:18: error: Unknown function 'malloc_proxy'
+  int *my_data = malloc(sizeof(int)); // Allocate memory for an integer on the heap
+                 ^~~~~~ 

--- a/src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c.cvc5
+++ b/src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c.cvc5
@@ -1,0 +1,11 @@
+return code: 1
+./src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c:35:15: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+              return == input; 
+              ~~~~~~~^~~~~~~~ 
+[1/2]: borrow -- pass
+[2/2]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c:44:15: error: Missing resource for reading
+    int ret = *r; // Safe to use 'r' here, as 'x' is still in scope
+              ^~ 
+Resource needed: Owned<signed int>(call_borrow0.return)
+State file: file:///tmp/state__00004-simple-lifetimes.c__main.html

--- a/src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c.z3
+++ b/src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c.z3
@@ -1,0 +1,11 @@
+return code: 1
+./src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c:35:15: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+              return == input; 
+              ~~~~~~~^~~~~~~~ 
+[1/2]: borrow -- pass
+[2/2]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00004-simple-lifetimes.c:44:15: error: Missing resource for reading
+    int ret = *r; // Safe to use 'r' here, as 'x' is still in scope
+              ^~ 
+Resource needed: Owned<signed int>(call_borrow0.return)
+State file: file:///tmp/state__00004-simple-lifetimes.c__main.html

--- a/src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c.cvc5
+++ b/src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c.cvc5
@@ -1,0 +1,11 @@
+return code: 1
+./src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c:37:15: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+              return == input; 
+              ~~~~~~~^~~~~~~~ 
+[1/2]: borrow -- pass
+[2/2]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c:51:2: error: Missing resource for writing
+	global_int = *r;
+	~~~~~~~~~~~^~~~ 
+Resource needed: Block<signed int>(&global_int)
+State file: file:///tmp/state__00006-lifetimes-broken.c__main.html

--- a/src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c.z3
+++ b/src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c.z3
@@ -1,0 +1,11 @@
+return code: 1
+./src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c:37:15: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+              return == input; 
+              ~~~~~~~^~~~~~~~ 
+[1/2]: borrow -- pass
+[2/2]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00006-lifetimes-broken.c:51:2: error: Missing resource for writing
+	global_int = *r;
+	~~~~~~~~~~~^~~~ 
+Resource needed: Block<signed int>(&global_int)
+State file: file:///tmp/state__00006-lifetimes-broken.c__main.html

--- a/src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c.cvc5
+++ b/src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c.cvc5
@@ -1,0 +1,14 @@
+return code: 1
+[1/3]: create_string -- fail
+[2/3]: copy_to_global -- fail
+[3/3]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c:41:15: error: Unknown function 'malloc_proxy'
+    char *s = malloc(20 * sizeof(char));  // Allocate memory for the string
+              ^~~~~~ 
+./src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c:51:31: error: Mismatched types.
+    strncpy(global_string, s, sizeof(global_string) - 1);
+                              ~~~~~~~~~~~~~~~~~~~~~~^~~ 
+Expected value of type 'u64' but found value of type 'u32'
+./src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c:62:5: error: Unknown function 'free_proxy'
+    free(my_string);  // Explicitly free the memory allocated in create_string
+    ^~~~ 

--- a/src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c.z3
+++ b/src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c.z3
@@ -1,0 +1,14 @@
+return code: 1
+[1/3]: create_string -- fail
+[2/3]: copy_to_global -- fail
+[3/3]: main -- fail
+./src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c:41:15: error: Unknown function 'malloc_proxy'
+    char *s = malloc(20 * sizeof(char));  // Allocate memory for the string
+              ^~~~~~ 
+./src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c:51:31: error: Mismatched types.
+    strncpy(global_string, s, sizeof(global_string) - 1);
+                              ~~~~~~~~~~~~~~~~~~~~~~^~~ 
+Expected value of type 'u64' but found value of type 'u32'
+./src/example-archive/Rust/broken/error-proof/00007-string-transfer-no-io.c:62:5: error: Unknown function 'free_proxy'
+    free(my_string);  // Explicitly free the memory allocated in create_string
+    ^~~~ 

--- a/src/example-archive/SAW/broken/error-cerberus/00001.swap.c.cvc5
+++ b/src/example-archive/SAW/broken/error-cerberus/00001.swap.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/SAW/broken/error-cerberus/00001.swap.c.z3
+++ b/src/example-archive/SAW/broken/error-cerberus/00001.swap.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/SAW/broken/error-cerberus/00007.u128.c.cvc5
+++ b/src/example-archive/SAW/broken/error-cerberus/00007.u128.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/SAW/broken/error-cerberus/00007.u128.c:83:13: error: use of undeclared identifier 'bcmp'
+    return !bcmp(x, y, 16);
+            ^

--- a/src/example-archive/SAW/broken/error-cerberus/00007.u128.c.z3
+++ b/src/example-archive/SAW/broken/error-cerberus/00007.u128.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/SAW/broken/error-cerberus/00007.u128.c:83:13: error: use of undeclared identifier 'bcmp'
+    return !bcmp(x, y, 16);
+            ^

--- a/src/example-archive/SAW/broken/error-cerberus/00008.salsa20.c.cvc5
+++ b/src/example-archive/SAW/broken/error-cerberus/00008.salsa20.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/SAW/broken/error-cerberus/salsa20.h:67:37: error: feature not yet supported: array parameter with the static keyword
+                            uint8_t nonce[static 8],
+                                    ^~~~~~~~~~~~~~~ 

--- a/src/example-archive/SAW/broken/error-cerberus/00008.salsa20.c.z3
+++ b/src/example-archive/SAW/broken/error-cerberus/00008.salsa20.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/SAW/broken/error-cerberus/salsa20.h:67:37: error: feature not yet supported: array parameter with the static keyword
+                            uint8_t nonce[static 8],
+                                    ^~~~~~~~~~~~~~~ 

--- a/src/example-archive/SAW/broken/error-proof/00002.popcount.c.cvc5
+++ b/src/example-archive/SAW/broken/error-proof/00002.popcount.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/3]: pop_count -- pass
+[2/3]: pop_count_mul -- pass
+[3/3]: pop_count_sparse -- fail
+./src/example-archive/SAW/broken/error-proof/00002.popcount.c:66:13: error: Undefined behaviour
+        n = n + 1;
+            ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00002.popcount.c__pop_count_sparse.html

--- a/src/example-archive/SAW/broken/error-proof/00002.popcount.c.z3
+++ b/src/example-archive/SAW/broken/error-proof/00002.popcount.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/3]: pop_count -- pass
+[2/3]: pop_count_mul -- pass
+[3/3]: pop_count_sparse -- fail
+./src/example-archive/SAW/broken/error-proof/00002.popcount.c:66:13: error: Undefined behaviour
+        n = n + 1;
+            ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00002.popcount.c__pop_count_sparse.html

--- a/src/example-archive/SAW/broken/error-proof/00003.point.c.cvc5
+++ b/src/example-archive/SAW/broken/error-proof/00003.point.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/SAW/broken/error-proof/00003.point.c.z3
+++ b/src/example-archive/SAW/broken/error-proof/00003.point.c.z3
@@ -1,0 +1,15 @@
+return code: 1
+[1/4]: point_eq -- fail
+[2/4]: point_new -- fail
+[3/4]: point_copy -- pass
+[4/4]: point_add -- pass
+./src/example-archive/SAW/broken/error-proof/00003.point.c:116:5: error: Unprovable constraint
+    return p1->x == p2->x && p1->y == p2-> y;
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+Constraint from ./src/example-archive/SAW/broken/error-proof/00003.point.c:109:7:
+	     if (vp11.x == vp21.x && vp11.y == vp21.x) {
+	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00003.point.c__point_eq.html
+./src/example-archive/SAW/broken/error-proof/00003.point.c:131:18: error: Unknown function 'malloc_proxy'
+    point* ret = malloc(sizeof(point));
+                 ^~~~~~ 

--- a/src/example-archive/SAW/broken/error-proof/00004.tutorial-dotprod.c.cvc5
+++ b/src/example-archive/SAW/broken/error-proof/00004.tutorial-dotprod.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/SAW/broken/error-proof/00004.tutorial-dotprod.c:53:5: error: unexpected token after '}' and before 'ensures'
+parsing "condition": seen "CN_TAKE LNAME VARIABLE EQ resource", expecting "SEMICOLON"
+    ensures  take ax1 = each(u32 j; 0u32 <= j && j < size) { Owned<uint32_t>(array_shift<uint32_t>(x,j)) };
+    ^~~~~~~ 

--- a/src/example-archive/SAW/broken/error-proof/00004.tutorial-dotprod.c.z3
+++ b/src/example-archive/SAW/broken/error-proof/00004.tutorial-dotprod.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/SAW/broken/error-proof/00004.tutorial-dotprod.c:53:5: error: unexpected token after '}' and before 'ensures'
+parsing "condition": seen "CN_TAKE LNAME VARIABLE EQ resource", expecting "SEMICOLON"
+    ensures  take ax1 = each(u32 j; 0u32 <= j && j < size) { Owned<uint32_t>(array_shift<uint32_t>(x,j)) };
+    ^~~~~~~ 

--- a/src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c.cvc5
+++ b/src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c.cvc5
@@ -1,0 +1,27 @@
+return code: 1
+[1/5]: ffs_ref -- fail
+[2/5]: ffs_imp -- pass
+[3/5]: ffs_imp_nobranch -- pass
+[4/5]: ffs_bug -- pass
+[5/5]: ffs_musl -- fail
+./src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c:42:19: error: Undefined behaviour
+        if(((1 << i++) & word) != 0)
+                  ~^~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00006.tutorial-ffs.c__ffs_ref.html
+./src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c:103:14: error: Missing resource for reading
+  return x ? debruijn32[(x&-x)*0x076be629 >> 27]+1 : 0;
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<char>(&(&&debruijn32[(u64)0'i32])[(u64)(
+                                                           !(
+                                                             0'i32
+                                                             <= 27'i32 /* 0x1b */
+                                                             && true
+                                                           ) ? 0'u32 :
+                                                           (
+                                                             (x & 0'u32 - x)
+                                                             * (u32)124511785'i32 /* 0x76be629 */
+                                                             >> (u32)27'i32 /* 0x1b */
+                                                           )
+                                                         )])
+State file: file:///tmp/state__00006.tutorial-ffs.c__ffs_musl.html

--- a/src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c.z3
+++ b/src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c.z3
@@ -1,0 +1,27 @@
+return code: 1
+[1/5]: ffs_ref -- fail
+[2/5]: ffs_imp -- pass
+[3/5]: ffs_imp_nobranch -- pass
+[4/5]: ffs_bug -- pass
+[5/5]: ffs_musl -- fail
+./src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c:42:19: error: Undefined behaviour
+        if(((1 << i++) & word) != 0)
+                  ~^~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00006.tutorial-ffs.c__ffs_ref.html
+./src/example-archive/SAW/broken/error-proof/00006.tutorial-ffs.c:103:14: error: Missing resource for reading
+  return x ? debruijn32[(x&-x)*0x076be629 >> 27]+1 : 0;
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<char>(&(&&debruijn32[(u64)0'i32])[(u64)(
+                                                           !(
+                                                             0'i32
+                                                             <= 27'i32 /* 0x1b */
+                                                             && true
+                                                           ) ? 0'u32 :
+                                                           (
+                                                             (x & 0'u32 - x)
+                                                             * (u32)124511785'i32 /* 0x76be629 */
+                                                             >> (u32)27'i32 /* 0x1b */
+                                                           )
+                                                         )])
+State file: file:///tmp/state__00006.tutorial-ffs.c__ffs_musl.html

--- a/src/example-archive/SAW/working/00005.tutorial-double.c.cvc5
+++ b/src/example-archive/SAW/working/00005.tutorial-double.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: double_ref -- pass
+[2/2]: double_imp -- pass

--- a/src/example-archive/SAW/working/00005.tutorial-double.c.z3
+++ b/src/example-archive/SAW/working/00005.tutorial-double.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: double_ref -- pass
+[2/2]: double_imp -- pass

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00025.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00025.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00025.err2.c:15:9: error: use of undeclared identifier 'strlen'
+	return strlen(p) - 5;
+        ^

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00025.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00025.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00025.err2.c:15:9: error: use of undeclared identifier 'strlen'
+	return strlen(p) - 5;
+        ^

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00042.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00042.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00042.err2.c:4:2: error: unsupported union types
+	union { int a; int b; } u;
+	^~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00042.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00042.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00042.err2.c:4:2: error: unsupported union types
+	union { int a; int b; } u;
+	^~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00046.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00046.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00046.err2.c:3:2: error: unsupported union types
+	union {
+	^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00046.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00046.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00046.err2.c:3:2: error: unsupported union types
+	union {
+	^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00050.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00050.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00050.err2.c:21:25: error: undefined behaviour: the initializer for a scalar shall be a single expression
+struct S2 v = {1, 2, 3, {4, 5}};
+                        ^~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00050.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00050.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00050.err2.c:21:25: error: undefined behaviour: the initializer for a scalar shall be a single expression
+struct S2 v = {1, 2, 3, {4, 5}};
+                        ^~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00056.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00056.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00056.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00056.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00087.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00087.err2.c.cvc5
@@ -1,0 +1,3 @@
+return code: 2
+unknown location  error: CoreTyping_TODO(the first operand of ccall() should have a C function type)
+error: this is likely a bug in the Core elaboration.

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00087.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00087.err2.c.z3
@@ -1,0 +1,3 @@
+return code: 2
+unknown location  error: CoreTyping_TODO(the first operand of ccall() should have a C function type)
+error: this is likely a bug in the Core elaboration.

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00089.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00089.err2.c.cvc5
@@ -1,0 +1,3 @@
+return code: 2
+unknown location  error: CoreTyping_TODO(the first operand of ccall() should have a C function type)
+error: this is likely a bug in the Core elaboration.

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00089.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00089.err2.c.z3
@@ -1,0 +1,3 @@
+return code: 2
+unknown location  error: CoreTyping_TODO(the first operand of ccall() should have a C function type)
+error: this is likely a bug in the Core elaboration.

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00095.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00095.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00095.err2.c:10:9: error: constraint violation: incompatible pointer types returning 'signed int (*) (void)' from a function with result type 'void*'
+	return &main;
+	^      ~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00095.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00095.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00095.err2.c:10:9: error: constraint violation: incompatible pointer types returning 'signed int (*) (void)' from a function with result type 'void*'
+	return &main;
+	^      ~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00113.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00113.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00113.err2.c:3:1: error: Unsupported C-type float
+{
+~      ^

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00113.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00113.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00113.err2.c:3:1: error: Unsupported C-type float
+{
+~      ^

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00119.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00119.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00119.err2.c:1:8: error: Unsupported C-type double
+double x = 100;
+       ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00119.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00119.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00119.err2.c:1:8: error: Unsupported C-type double
+double x = 100;
+       ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00123.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00123.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00123.err2.c:1:8: error: Unsupported C-type double
+double x = 100.0;
+       ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00123.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00123.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00123.err2.c:1:8: error: Unsupported C-type double
+double x = 100.0;
+       ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00125.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00125.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00125.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00125.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00131.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00131.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00131.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00131.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00132.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00132.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00132.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00132.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00140.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00140.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00140.err2.c:1:1: error: Unsupported C-type float
+struct foo {
+~~~~~~~^~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00140.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00140.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00140.err2.c:1:1: error: Unsupported C-type float
+struct foo {
+~~~~~~~^~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00144.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00144.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00144.err2.c:10:6: error: constraint violation: assigning to 'void*' from 'const void*' discards qualifiers
+	p = i ? 0 : (const void *) 0;
+	  ^ ~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00144.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00144.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00144.err2.c:10:6: error: constraint violation: assigning to 'void*' from 'const void*' discards qualifiers
+	p = i ? 0 : (const void *) 0;
+	  ^ ~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00149.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00149.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00149.err2.c:2:15: error: constraint violation: initializer element is not a compile-time constant
+struct S *s = &(struct S) { 1, 2 };
+              ^~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00149.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00149.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00149.err2.c:2:15: error: constraint violation: initializer element is not a compile-time constant
+struct S *s = &(struct S) { 1, 2 };
+              ^~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00150.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00150.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00150.err2.c:11:16: error: constraint violation: initializer element is not a compile-time constant
+struct S2 *s = &(struct S2) {
+               ^~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00150.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00150.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00150.err2.c:11:16: error: constraint violation: initializer element is not a compile-time constant
+struct S2 *s = &(struct S2) {
+               ^~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00154.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00154.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00154.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00154.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00156.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00156.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00156.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00156.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00157.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00157.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00157.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00157.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00158.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00158.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00158.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00158.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00159.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00159.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00159.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00159.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00160.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00160.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00160.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00160.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00161.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00161.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00161.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00161.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00162.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00162.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00162.err2.c:3:15: error: feature not yet supported: array parameter with the static keyword
+void foos(int x[static 5]);
+              ^~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00162.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00162.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00162.err2.c:3:15: error: feature not yet supported: array parameter with the static keyword
+void foos(int x[static 5]);
+              ^~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00163.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00163.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00163.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00163.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00164.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00164.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00164.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00164.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00165.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00165.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00165.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00165.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00166.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00166.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00166.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00166.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00167.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00167.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00167.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00167.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00168.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00168.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00168.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00168.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00169.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00169.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00169.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00169.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00170.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00170.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00170.err2.c:22:6: error: such construction is not allowed for enumerators
+enum efoo;
+     ^~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00170.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00170.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00170.err2.c:22:6: error: such construction is not allowed for enumerators
+enum efoo;
+     ^~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00171.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00171.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00171.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00171.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00172.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00172.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00172.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00172.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00173.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00173.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00173.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00173.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00174.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00174.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00174.err2.c:45:19: error: use of undeclared identifier 'sin'
+   printf("%f\n", sin(2));
+                  ^

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00174.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00174.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00174.err2.c:45:19: error: use of undeclared identifier 'sin'
+   printf("%f\n", sin(2));
+                  ^

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00175.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00175.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00175.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00175.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00176.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00176.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00176.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00176.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00177.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00177.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00177.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00177.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00178.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00178.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00178.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00178.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00179.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00179.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00179.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00179.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00180.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00180.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00180.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00180.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00181.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00181.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00181.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00181.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00183.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00183.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00183.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00183.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00184.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00184.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00184.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00184.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00185.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00185.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00185.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00185.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00186.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00186.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00186.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00186.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00187.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00187.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00187.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00187.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00188.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00188.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00188.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00188.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00189.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00189.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00189.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00189.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00190.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00190.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00190.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00190.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00191.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00191.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00191.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00191.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00192.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00192.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00192.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00192.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00193.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00193.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00193.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00193.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00194.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00194.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00194.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00194.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00195.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00195.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00195.err2.c:3:1: error: Unsupported C-type double
+struct point
+~~~~~~~^~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00195.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00195.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00195.err2.c:3:1: error: Unsupported C-type double
+struct point
+~~~~~~~^~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00196.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00196.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00196.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00196.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00197.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00197.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00197.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00197.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00198.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00198.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00198.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00198.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00199.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00199.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00199.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00199.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00201.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00201.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00201.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00201.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00202.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00202.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00202.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00202.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00203.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00203.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00203.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00203.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00204.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00204.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00204.err2.c:8:33: error: constraint violation: initializing 'char' with an expression with a non arithmetic type 'char*'
+struct s1 { char x[1]; } s1 = { "0" };
+                                ^~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00204.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00204.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00204.err2.c:8:33: error: constraint violation: initializing 'char' with an expression with a non arithmetic type 'char*'
+struct s1 { char x[1]; } s1 = { "0" };
+                                ^~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00205.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00205.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00205.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00205.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00206.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00206.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00206.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00206.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00207.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00207.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00207.err2.c:6:8: error: feature not yet supported: variable length array type 2
+  char test[argc];
+       ^~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00207.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00207.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00207.err2.c:6:8: error: feature not yet supported: variable length array type 2
+  char test[argc];
+       ^~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00208.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00208.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00208.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00208.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00209.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00209.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00209.err2.c:3:1: error: constraint violation: incomplete enum type
+enum E *e;
+^~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00209.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00209.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00209.err2.c:3:1: error: constraint violation: incomplete enum type
+enum E *e;
+^~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00210.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00210.err2.c.cvc5
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00210.err2.c:7:17: error: unexpected token after '(' and before '('
+Please add error message for state 382 to parsers/c/c_parser_error.messages
+} __attribute__((packed)) Unaligned16a;
+                ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00210.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00210.err2.c.z3
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00210.err2.c:7:17: error: unexpected token after '(' and before '('
+Please add error message for state 382 to parsers/c/c_parser_error.messages
+} __attribute__((packed)) Unaligned16a;
+                ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00211.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00211.err2.c.cvc5
@@ -1,0 +1,6 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00211.err2.c:17:5: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'signed int', conv_loaded_int('signed int', a_650))
+
+    printf("n+1 = %d\n", n+1);
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00211.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00211.err2.c.z3
@@ -1,0 +1,6 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00211.err2.c:17:5: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'signed int', conv_loaded_int('signed int', a_650))
+
+    printf("n+1 = %d\n", n+1);
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00212.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00212.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00212.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00212.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+/home/dhruv/.opam/5.2.0/lib/cerberus/runtime/libc/include/stdio.h:58:5: error: unsupported variadic functions
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...);
+    ^~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00213.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00213.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00213.err2.c:21:6: error: constraint violation: use of undeclared label 'some_label'
+	    some_label:
+	    ^~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00213.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00213.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00213.err2.c:21:6: error: constraint violation: use of undeclared label 'some_label'
+	    some_label:
+	    ^~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c.cvc5
@@ -1,0 +1,31 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:13:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_1097))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:26:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_1031))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:39:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_971))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:53:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_914))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:67:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_858))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:83:9: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_764))
+
+	if (1) printf("timeout=%ld\n", timeout);
+	       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c.z3
@@ -1,0 +1,31 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:13:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_1097))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:26:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_1031))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:39:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_971))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:53:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_914))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:67:16: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_858))
+
+        if (1) printf("timeout=%ld\n", timeout);
+               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+./src/example-archive/c-testsuite/broken/error-cerberus/00215.err2.c:83:9: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'unsigned long', conv_loaded_int('unsigned long', a_764))
+
+	if (1) printf("timeout=%ld\n", timeout);
+	       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00216.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00216.err2.c.cvc5
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00216.err2.c:8:49: error: unexpected token after '{' and before '}'
+parsing "postfix_expression": seen "LPAREN type_name RPAREN LBRACE", expecting "initializer_list option(COMMA) RBRACE"
+struct contains_empty ce = { { (1) }, (empty_s){}, 022, };
+                                                ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00216.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00216.err2.c.z3
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00216.err2.c:8:49: error: unexpected token after '{' and before '}'
+parsing "postfix_expression": seen "LPAREN type_name RPAREN LBRACE", expecting "initializer_list option(COMMA) RBRACE"
+struct contains_empty ce = { { (1) }, (empty_s){}, 022, };
+                                                ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00217.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00217.err2.c.cvc5
@@ -1,0 +1,6 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00217.err2.c:20:5: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'char*', a_693)
+
+    printf("data = \"%s\"\n", data);
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00217.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00217.err2.c.z3
@@ -1,0 +1,6 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00217.err2.c:20:5: error: Eproc:
+TODO_expr ==> pcall(create_and_store, 'char*', a_693)
+
+    printf("data = \"%s\"\n", data);
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00218.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00218.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00218.err2.c:15:25: error: feature not yet supported: bit-fields
+  enum tree_code code : 8;
+                        ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00218.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00218.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00218.err2.c:15:25: error: feature not yet supported: bit-fields
+  enum tree_code code : 8;
+                        ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00219.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00219.err2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00219.err2.c:42:6: error: feature not yet supported: C11 generic selection
+	i = _Generic(a, int: a_f, const int: b_f)();
+	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00219.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00219.err2.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00219.err2.c:42:6: error: feature not yet supported: C11 generic selection
+	i = _Generic(a, int: a_f, const int: b_f)();
+	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00220.err2.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00220.err2.c.cvc5
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00220.err2.c:7:13: error: unexpected token after 'wchar_t' and before 's'
+Please add error message for state 604 to parsers/c/c_parser_error.messages
+    wchar_t s[] = L"hello$$你好¢¢世界€€world";
+            ^ 

--- a/src/example-archive/c-testsuite/broken/error-cerberus/00220.err2.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-cerberus/00220.err2.c.z3
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/c-testsuite/broken/error-cerberus/00220.err2.c:7:13: error: unexpected token after 'wchar_t' and before 's'
+Please add error message for state 604 to parsers/c/c_parser_error.messages
+    wchar_t s[] = L"hello$$你好¢¢世界€€world";
+            ^ 

--- a/src/example-archive/c-testsuite/broken/error-crash/00091.err125.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-crash/00091.err125.c.cvc5
@@ -1,0 +1,28 @@
+return code: 125
+internal error: TODO: do_next_in_same_level _
+cn: internal error, uncaught exception:
+    Failure("internal error: TODO: do_next_in_same_level _")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Desugaring_init.interp_initializer_aux.(fun) in file "ocaml_frontend/generated/desugaring_init.ml", line 511, characters 22-59
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.state_except_eval.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 94, characters 94-99
+    Called from Cerb_backend__Pipeline.c_frontend.desugar in file "backend/common/pipeline.ml", lines 191-192, characters 4-23
+    Called from Cerb_backend__Pipeline.c_frontend.(fun) in file "backend/common/pipeline.ml", line 233, characters 2-20
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration in file "backend/common/pipeline.ml", line 238, characters 2-73
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/c-testsuite/broken/error-crash/00091.err125.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-crash/00091.err125.c.z3
@@ -1,0 +1,28 @@
+return code: 125
+internal error: TODO: do_next_in_same_level _
+cn: internal error, uncaught exception:
+    Failure("internal error: TODO: do_next_in_same_level _")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Desugaring_init.interp_initializer_aux.(fun) in file "ocaml_frontend/generated/desugaring_init.ml", line 511, characters 22-59
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.state_except_eval.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 94, characters 94-99
+    Called from Cerb_backend__Pipeline.c_frontend.desugar in file "backend/common/pipeline.ml", lines 191-192, characters 4-23
+    Called from Cerb_backend__Pipeline.c_frontend.(fun) in file "backend/common/pipeline.ml", line 233, characters 2-20
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration in file "backend/common/pipeline.ml", line 238, characters 2-73
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/c-testsuite/broken/error-crash/00214.err125.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-crash/00214.err125.c.cvc5
@@ -1,0 +1,12 @@
+return code: 125
+unsupported: ./src/example-archive/c-testsuite/broken/error-crash/00214.err125.c:42:4:: GCC statements as expressions not yet supported
+internal error: ./src/example-archive/c-testsuite/broken/error-crash/00214.err125.c:42:4:: GCC statements as expressions not yet supported
+cn: internal error, uncaught exception:
+    Failure("internal error: ./src/example-archive/c-testsuite/broken/error-crash/00214.err125.c:42:4:: GCC statements as expressions not yet supported")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Translation.translate in file "ocaml_frontend/generated/translation.ml", line 4452, characters 4-92
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration.(fun) in file "backend/common/pipeline.ml", line 245, characters 18-92
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/c-testsuite/broken/error-crash/00214.err125.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-crash/00214.err125.c.z3
@@ -1,0 +1,12 @@
+return code: 125
+unsupported: ./src/example-archive/c-testsuite/broken/error-crash/00214.err125.c:42:4:: GCC statements as expressions not yet supported
+internal error: ./src/example-archive/c-testsuite/broken/error-crash/00214.err125.c:42:4:: GCC statements as expressions not yet supported
+cn: internal error, uncaught exception:
+    Failure("internal error: ./src/example-archive/c-testsuite/broken/error-crash/00214.err125.c:42:4:: GCC statements as expressions not yet supported")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Translation.translate in file "ocaml_frontend/generated/translation.ml", line 4452, characters 4-92
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration.(fun) in file "backend/common/pipeline.ml", line 245, characters 18-92
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/c-testsuite/broken/error-proof/00008.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00008.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00008.err1.c:11:7: error: Undefined behaviour
+		x = x - 1;
+		    ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00008.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00008.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00008.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00008.err1.c:11:7: error: Undefined behaviour
+		x = x - 1;
+		    ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00008.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00010.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00010.err1.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/c-testsuite/broken/error-proof/00010.err1.c:14:3: error: undefined code label
+success
+		goto success;
+		^~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-proof/00010.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00010.err1.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/c-testsuite/broken/error-proof/00010.err1.c:14:3: error: undefined code label
+success
+		goto success;
+		^~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-proof/00026.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00026.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00026.err1.c:14:9: error: Missing resource for reading
+	return p[0] - 104;
+	       ^~~~ 
+Resource needed: Owned<char>(&a_630[(u64)0'i32])
+State file: file:///tmp/state__00026.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00026.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00026.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00026.err1.c:14:9: error: Missing resource for reading
+	return p[0] - 104;
+	       ^~~~ 
+Resource needed: Owned<char>(&a_630[(u64)0'i32])
+State file: file:///tmp/state__00026.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00034.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00034.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00034.err1.c:30:7: error: Undefined behaviour
+		x = x + 1;
+		    ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00034.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00034.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00034.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00034.err1.c:30:7: error: Undefined behaviour
+		x = x + 1;
+		    ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00034.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00038.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00038.err1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00038.err1.c:16:6: error: Mismatched types.
+	if (sizeof(int) - 2 < 0)
+	    ~~~~~~~~~~~~^~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/c-testsuite/broken/error-proof/00038.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00038.err1.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00038.err1.c:16:6: error: Mismatched types.
+	if (sizeof(int) - 2 < 0)
+	    ~~~~~~~~~~~~^~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/c-testsuite/broken/error-proof/00040.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00040.err1.c.cvc5
@@ -1,0 +1,17 @@
+return code: 1
+[1/3]: chk -- fail
+[2/3]: go -- fail
+[3/3]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00040.err1.c:15:25: error: Missing resource for reading
+                r = r + t[x + 8*i];
+                        ^ 
+Resource needed: Owned<signed int*>(&t)
+State file: file:///tmp/state__00040.err1.c__chk.html
+./src/example-archive/c-testsuite/broken/error-proof/00040.err1.c:33:17: error: Missing resource for reading
+                N++;
+                ~^~ 
+Resource needed: Owned<signed int>(&N)
+State file: file:///tmp/state__00040.err1.c__go.html
+./src/example-archive/c-testsuite/broken/error-proof/00040.err1.c:52:13: error: Call to function with no spec: calloc
+        t = calloc(64, sizeof(int));
+            ^~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-proof/00040.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00040.err1.c.z3
@@ -1,0 +1,17 @@
+return code: 1
+[1/3]: chk -- fail
+[2/3]: go -- fail
+[3/3]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00040.err1.c:15:25: error: Missing resource for reading
+                r = r + t[x + 8*i];
+                        ^ 
+Resource needed: Owned<signed int*>(&t)
+State file: file:///tmp/state__00040.err1.c__chk.html
+./src/example-archive/c-testsuite/broken/error-proof/00040.err1.c:33:17: error: Missing resource for reading
+                N++;
+                ~^~ 
+Resource needed: Owned<signed int>(&N)
+State file: file:///tmp/state__00040.err1.c__go.html
+./src/example-archive/c-testsuite/broken/error-proof/00040.err1.c:52:13: error: Call to function with no spec: calloc
+        t = calloc(64, sizeof(int));
+            ^~~~~~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-proof/00041.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00041.err1.c.cvc5
@@ -1,0 +1,8 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00041.err1.c:15:2: error: Missing resource for loop
+	while (n < 5000) {
+	^~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&t)
+      ./src/example-archive/c-testsuite/broken/error-proof/00041.err1.c:15:2: (arg O_t0)
+State file: file:///tmp/state__00041.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00041.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00041.err1.c.z3
@@ -1,0 +1,8 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00041.err1.c:15:2: error: Missing resource for loop
+	while (n < 5000) {
+	^~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&t)
+      ./src/example-archive/c-testsuite/broken/error-proof/00041.err1.c:15:2: (arg O_t0)
+State file: file:///tmp/state__00041.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00058.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00058.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00058.err1.c:13:5: error: Missing resource for reading
+	if(s[0] != 'a') return 1;
+	   ^~~~ 
+Resource needed: Owned<char>(&a_637[(u64)0'i32])
+State file: file:///tmp/state__00058.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00058.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00058.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00058.err1.c:13:5: error: Missing resource for reading
+	if(s[0] != 'a') return 1;
+	   ^~~~ 
+Resource needed: Owned<char>(&a_637[(u64)0'i32])
+State file: file:///tmp/state__00058.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00073.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00073.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00073.err1.c:15:2: error: Missing resource for writing
+	*p = 123;
+	~~~^~~~~ 
+Resource needed: Block<signed int>(&arr)
+State file: file:///tmp/state__00073.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00073.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00073.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00073.err1.c:15:2: error: Missing resource for writing
+	*p = 123;
+	~~~^~~~~ 
+Resource needed: Block<signed int>(&arr)
+State file: file:///tmp/state__00073.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00077.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00077.err1.c.cvc5
@@ -1,0 +1,13 @@
+return code: 1
+[1/2]: foo -- fail
+[2/2]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00077.err1.c:14:5: error: `&x[(u64)0'i32]` out of bounds
+	if(x[0] != 1000)
+	   ^~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00077.err1.c__foo.html
+./src/example-archive/c-testsuite/broken/error-proof/00077.err1.c:51:2: error: Static error
+	assert(0); 
+	^~~~~~~~~ 
+assert() failure
+State file: file:///tmp/state__00077.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00077.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00077.err1.c.z3
@@ -1,0 +1,13 @@
+return code: 1
+[1/2]: foo -- fail
+[2/2]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00077.err1.c:14:5: error: `&x[(u64)0'i32]` out of bounds
+	if(x[0] != 1000)
+	   ^~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00077.err1.c__foo.html
+./src/example-archive/c-testsuite/broken/error-proof/00077.err1.c:51:2: error: Static error
+	assert(0); 
+	^~~~~~~~~ 
+assert() failure
+State file: file:///tmp/state__00077.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00088.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00088.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00088.err1.c:7:6: error: Missing resource for reading
+	if (fptr)
+	    ^~~~ 
+Resource needed: Owned<signed int ()*>(&fptr)
+State file: file:///tmp/state__00088.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00088.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00088.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00088.err1.c:7:6: error: Missing resource for reading
+	if (fptr)
+	    ^~~~ 
+Resource needed: Owned<signed int ()*>(&fptr)
+State file: file:///tmp/state__00088.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00092.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00092.err1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00092.err1.c:9:19: error: Mismatched types.
+	if (sizeof(a) != 4*sizeof(int))
+	                 ~^~~~~~~~~~~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/c-testsuite/broken/error-proof/00092.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00092.err1.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00092.err1.c:9:19: error: Mismatched types.
+	if (sizeof(a) != 4*sizeof(int))
+	                 ~^~~~~~~~~~~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/c-testsuite/broken/error-proof/00093.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00093.err1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00093.err1.c:9:19: error: Mismatched types.
+	if (sizeof(a) != 4*sizeof(int))
+	                 ~^~~~~~~~~~~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/c-testsuite/broken/error-proof/00093.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00093.err1.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00093.err1.c:9:19: error: Mismatched types.
+	if (sizeof(a) != 4*sizeof(int))
+	                 ~^~~~~~~~~~~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/c-testsuite/broken/error-proof/00101.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00101.err1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00101.err1.c:12:3: error: Unprovable constraint
+  return c;
+  ^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00101.err1.c:5:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00101.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00101.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00101.err1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00101.err1.c:12:3: error: Unprovable constraint
+  return c;
+  ^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00101.err1.c:5:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00101.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00103.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00103.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00103.err1.c:14:10: error: Missing resource for reading
+	return **(int**)bar;
+	        ^~~~~~~~~~~ 
+Resource needed: Owned<signed int*>(&foo)
+State file: file:///tmp/state__00103.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00103.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00103.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00103.err1.c:14:10: error: Missing resource for reading
+	return **(int**)bar;
+	        ^~~~~~~~~~~ 
+Resource needed: Owned<signed int*>(&foo)
+State file: file:///tmp/state__00103.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00110.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00110.err1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00110.err1.c:9:2: error: Unprovable constraint
+	return x;
+	^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00110.err1.c:7:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00110.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00110.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00110.err1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00110.err1.c:9:2: error: Unprovable constraint
+	return x;
+	^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00110.err1.c:7:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00110.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00115.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00115.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00115.err1.c:10:6: error: Missing resource for reading
+	if (s[0] != 'a')
+	    ^~~~ 
+Resource needed: Owned<char>(&(&&s[(u64)0'i32])[(u64)0'i32])
+State file: file:///tmp/state__00115.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00115.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00115.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00115.err1.c:10:6: error: Missing resource for reading
+	if (s[0] != 'a')
+	    ^~~~ 
+Resource needed: Owned<char>(&(&&s[(u64)0'i32])[(u64)0'i32])
+State file: file:///tmp/state__00115.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00117.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00117.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00117.err1.c:21:9: error: Missing resource for reading
+	return x[1];
+	       ^~~~ 
+Resource needed: Owned<signed int>(&(&&x[(u64)0'i32])[(u64)1'i32])
+State file: file:///tmp/state__00117.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00117.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00117.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00117.err1.c:21:9: error: Missing resource for reading
+	return x[1];
+	       ^~~~ 
+Resource needed: Owned<signed int>(&(&&x[(u64)0'i32])[(u64)1'i32])
+State file: file:///tmp/state__00117.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00124.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00124.err1.c.cvc5
@@ -1,0 +1,13 @@
+return code: 1
+[1/3]: f2 -- fail
+[2/3]: f1 -- pass
+[3/3]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00124.err1.c:4:9: error: Undefined behaviour
+	return c - b;
+	       ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00124.err1.c__f2.html
+./src/example-archive/c-testsuite/broken/error-proof/00124.err1.c:22:9: error: function pointer must be provably equal to a defined function:
+call_f10.return
+	return (*(*p)(0, 2))(2, 2);
+	       ^~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-proof/00124.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00124.err1.c.z3
@@ -1,0 +1,13 @@
+return code: 1
+[1/3]: f2 -- fail
+[2/3]: f1 -- pass
+[3/3]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00124.err1.c:4:9: error: Undefined behaviour
+	return c - b;
+	       ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00124.err1.c__f2.html
+./src/example-archive/c-testsuite/broken/error-proof/00124.err1.c:22:9: error: function pointer must be provably equal to a defined function:
+call_f10.return
+	return (*(*p)(0, 2))(2, 2);
+	       ^~~~~~~~~~~~~~~~~~~ 

--- a/src/example-archive/c-testsuite/broken/error-proof/00127.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00127.err1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00127.err1.c:14:5: error: Unprovable constraint
+				return 1;
+				^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00127.err1.c:6:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00127.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00127.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00127.err1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00127.err1.c:14:5: error: Unprovable constraint
+				return 1;
+				^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00127.err1.c:6:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00127.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00130.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00130.err1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00130.err1.c:10:2: error: Missing resource for writing
+	arr[1][3] = 2;
+	~~~~~~~~~~^~~ 
+Resource needed: Block<char>(&(&(&(&&arr[(u64)0'i32])[(u64)1'i32])[(u64)0'i32])[(
+                                                                                  u64
+                                                                                )3'i32])
+State file: file:///tmp/state__00130.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00130.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00130.err1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00130.err1.c:10:2: error: Missing resource for writing
+	arr[1][3] = 2;
+	~~~~~~~~~~^~~ 
+Resource needed: Block<char>(&(&(&(&&arr[(u64)0'i32])[(u64)1'i32])[(u64)0'i32])[(
+                                                                                  u64
+                                                                                )3'i32])
+State file: file:///tmp/state__00130.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00133.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00133.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00133.err1.c:10:2: error: integer value not representable at type signed int
+	i = -1u;
+	~~^~~~~ 
+Value: 0'u32 - 1'u32
+State file: file:///tmp/state__00133.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00133.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00133.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00133.err1.c:10:2: error: integer value not representable at type signed int
+	i = -1u;
+	~~^~~~~ 
+Value: 0'u32 - 1'u32
+State file: file:///tmp/state__00133.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00137.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00137.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00137.err1.c:16:10: error: Missing resource for reading
+	return (*p == 'h') ? 0 : 1;
+	        ^~ 
+Resource needed: Owned<char>(a_630)
+State file: file:///tmp/state__00137.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00137.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00137.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00137.err1.c:16:10: error: Missing resource for reading
+	return (*p == 'h') ? 0 : 1;
+	        ^~ 
+Resource needed: Owned<char>(a_630)
+State file: file:///tmp/state__00137.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00138.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00138.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00138.err1.c:16:10: error: Missing resource for reading
+	return (a[1] == 'i') ? 0 : 1;
+	        ^~~~ 
+Resource needed: Owned<char>(&a_630[(u64)1'i32])
+State file: file:///tmp/state__00138.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00138.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00138.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00138.err1.c:16:10: error: Missing resource for reading
+	return (a[1] == 'i') ? 0 : 1;
+	        ^~~~ 
+Resource needed: Owned<char>(&a_630[(u64)1'i32])
+State file: file:///tmp/state__00138.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00141.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00141.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00141.err1.c:14:11: error: Missing resource for reading
+	CAT(foo,bar) = foo + bar;
+	         ^~~ 
+Resource needed: Owned<signed int>(&foo)
+State file: file:///tmp/state__00141.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00141.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00141.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00141.err1.c:14:11: error: Missing resource for reading
+	CAT(foo,bar) = foo + bar;
+	         ^~~ 
+Resource needed: Owned<signed int>(&foo)
+State file: file:///tmp/state__00141.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00142.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00142.err1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00142.err1.c:16:2: error: Unprovable constraint
+	return c;
+	^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00142.err1.c:14:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00142.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00142.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00142.err1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00142.err1.c:16:2: error: Unprovable constraint
+	return c;
+	^~~~~~~~~ 
+Constraint from ./src/example-archive/c-testsuite/broken/error-proof/00142.err1.c:14:13:
+/*@ ensures return == 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00142.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00147.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00147.err1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00147.err1.c:7:5: error: Missing resource for reading
+	if(arr[0] != 0)
+	   ^~~~~~ 
+Resource needed: Owned<signed int>(&(&&arr[(u64)0'i32])[(u64)0'i32])
+State file: file:///tmp/state__00147.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00147.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00147.err1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00147.err1.c:7:5: error: Missing resource for reading
+	if(arr[0] != 0)
+	   ^~~~~~ 
+Resource needed: Owned<signed int>(&(&&arr[(u64)0'i32])[(u64)0'i32])
+State file: file:///tmp/state__00147.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00148.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00148.err1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00148.err1.c:8:5: error: Pointer `&(&&arr[(u64)0'i32])[(u64)0'i32]` needs to be live for member shift
+	if(arr[0].a != 1)
+	   ~~~~~~^~ 
+Need an Alloc or Owned in context with same allocation id

--- a/src/example-archive/c-testsuite/broken/error-proof/00148.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00148.err1.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00148.err1.c:8:5: error: Pointer `&(&&arr[(u64)0'i32])[(u64)0'i32]` needs to be live for member shift
+	if(arr[0].a != 1)
+	   ~~~~~~^~ 
+Need an Alloc or Owned in context with same allocation id

--- a/src/example-archive/c-testsuite/broken/error-proof/00151.err1.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-proof/00151.err1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00151.err1.c:17:11: error: Missing resource for reading
+	return !(arr[0][1][4] == arr[1][1][4]);
+	         ^~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&(
+    &(&(&(&(&&arr[(u64)0'i32])[(u64)0'i32])[(u64)0'i32])[(u64)1'i32])[(u64)0'i32]
+  )[(u64)4'i32])
+State file: file:///tmp/state__00151.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-proof/00151.err1.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-proof/00151.err1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-proof/00151.err1.c:17:11: error: Missing resource for reading
+	return !(arr[0][1][4] == arr[1][1][4]);
+	         ^~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&(
+    &(&(&(&(&&arr[(u64)0'i32])[(u64)0'i32])[(u64)0'i32])[(u64)1'i32])[(u64)0'i32]
+  )[(u64)4'i32])
+State file: file:///tmp/state__00151.err1.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-timeout/00051.timeout.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00051.timeout.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/broken/error-timeout/00051.timeout.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00051.timeout.c.z3
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/broken/error-timeout/00143.timeout.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00143.timeout.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/broken/error-timeout/00143.timeout.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00143.timeout.c.z3
@@ -1,0 +1,8 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/c-testsuite/broken/error-timeout/00143.timeout.c:14:5: error: Missing resource for loop
+    for(n = 0; n < 39; n++) {
+    ^~~~~~~~~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&count)
+      ./src/example-archive/c-testsuite/broken/error-timeout/00143.timeout.c:14:5: (arg O_count1)
+State file: file:///tmp/state__00143.timeout.c__main.html

--- a/src/example-archive/c-testsuite/broken/error-timeout/00182.timeout.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00182.timeout.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/broken/error-timeout/00182.timeout.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00182.timeout.c.z3
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/broken/error-timeout/00200.timeout.c.cvc5
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00200.timeout.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/broken/error-timeout/00200.timeout.c.z3
+++ b/src/example-archive/c-testsuite/broken/error-timeout/00200.timeout.c.z3
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/c-testsuite/working/00001.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00001.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00001.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00001.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00002.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00002.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00002.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00002.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00003.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00003.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00003.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00003.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00004.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00004.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00004.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00004.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00005.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00005.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00005.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00005.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00006.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00006.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00006.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00006.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00007.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00007.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00007.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00007.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00011.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00011.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00011.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00011.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00012.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00012.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00012.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00012.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00013.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00013.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00013.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00013.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00014.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00014.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00014.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00014.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00015.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00015.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00015.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00015.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00016.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00016.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00016.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00016.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00017.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00017.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00017.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00017.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00018.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00018.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00018.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00018.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00019.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00019.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00019.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00019.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00020.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00020.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00020.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00020.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00021.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00021.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: foo -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00021.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00021.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: foo -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00022.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00022.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00022.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00022.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00023.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00023.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00023.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00023.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00024.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00024.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00024.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00024.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00027.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00027.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00027.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00027.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00028.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00028.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00028.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00028.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00029.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00029.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00029.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00029.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00030.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00030.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00030.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00030.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00031.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00031.working.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: zero -- pass
+[2/3]: one -- pass
+[3/3]: main -- pass

--- a/src/example-archive/c-testsuite/working/00031.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00031.working.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: zero -- pass
+[2/3]: one -- pass
+[3/3]: main -- pass

--- a/src/example-archive/c-testsuite/working/00032.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00032.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00032.c.z3
+++ b/src/example-archive/c-testsuite/working/00032.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00033.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00033.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: effect -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00033.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00033.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: effect -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00035.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00035.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00035.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00035.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00036.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00036.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00036.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00036.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00037.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00037.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00037.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00037.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00039.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00039.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00039.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00039.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00043.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00043.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00043.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00043.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00044.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00044.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00044.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00044.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00045.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00045.working.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/c-testsuite/working/00045.working.c:11:4: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+			p == &x; @*/
+			~~^~~~~ 
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00045.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00045.working.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/c-testsuite/working/00045.working.c:11:4: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+			p == &x; @*/
+			~~^~~~~ 
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00047.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00047.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00047.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00047.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00048.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00048.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00048.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00048.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00049.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00049.working.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/c-testsuite/working/00049.working.c:11:4: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+			s.p == &x; s.a == 1i32; @*/
+			~~~~^~~~~ 
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00049.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00049.working.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/c-testsuite/working/00049.working.c:11:4: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+			s.p == &x; s.a == 1i32; @*/
+			~~~~^~~~~ 
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00052.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00052.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00052.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00052.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00053.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00053.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00053.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00053.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00054.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00054.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00054.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00054.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00055.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00055.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00055.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00055.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00057.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00057.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00057.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00057.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00059.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00059.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00059.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00059.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00060.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00060.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00060.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00060.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00061.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00061.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00061.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00061.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00062.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00062.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00062.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00062.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00063.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00063.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00063.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00063.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00064.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00064.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00064.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00064.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00065.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00065.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00065.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00065.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00066.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00066.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00066.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00066.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00067.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00067.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00067.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00067.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00068.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00068.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00068.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00068.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00069.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00069.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00069.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00069.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00070.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00070.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00070.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00070.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00071.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00071.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00071.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00071.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00072.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00072.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00072.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00072.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00074.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00074.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00074.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00074.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00075.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00075.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00075.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00075.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00076.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00076.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00076.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00076.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00078.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00078.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f1 -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00078.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00078.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f1 -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00079.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00079.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00079.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00079.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00080.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00080.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: voidfn -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00080.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00080.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: voidfn -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00081.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00081.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00081.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00081.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00082.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00082.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00082.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00082.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00083.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00083.working.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: one -- pass
+[2/4]: two -- pass
+[3/4]: three -- pass
+[4/4]: main -- pass

--- a/src/example-archive/c-testsuite/working/00083.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00083.working.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: one -- pass
+[2/4]: two -- pass
+[3/4]: three -- pass
+[4/4]: main -- pass

--- a/src/example-archive/c-testsuite/working/00084.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00084.working.c.cvc5
@@ -1,0 +1,6 @@
+return code: 0
+[1/5]: none -- pass
+[2/5]: one -- pass
+[3/5]: two -- pass
+[4/5]: three -- pass
+[5/5]: main -- pass

--- a/src/example-archive/c-testsuite/working/00084.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00084.working.c.z3
@@ -1,0 +1,6 @@
+return code: 0
+[1/5]: none -- pass
+[2/5]: one -- pass
+[3/5]: two -- pass
+[4/5]: three -- pass
+[5/5]: main -- pass

--- a/src/example-archive/c-testsuite/working/00085.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00085.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00085.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00085.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00086.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00086.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00086.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00086.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00090.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00090.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00090.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00090.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00094.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00094.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00094.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00094.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00096.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00096.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00096.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00096.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00097.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00097.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00097.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00097.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00098.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00098.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00098.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00098.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00099.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00099.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: vecresize -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00099.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00099.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: vecresize -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00100.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00100.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: foo -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00100.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00100.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: foo -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00102.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00102.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00102.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00102.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00104.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00104.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00104.c.z3
+++ b/src/example-archive/c-testsuite/working/00104.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00105.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00105.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00105.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00105.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00106.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00106.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00106.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00106.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00107.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00107.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00107.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00107.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00108.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00108.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00108.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00108.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00109.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00109.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00109.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00109.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00111.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00111.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00111.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00111.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00112.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00112.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00112.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00112.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00114.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00114.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00114.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00114.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00116.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00116.working.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00116.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00116.working.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f -- pass
+[2/2]: main -- pass

--- a/src/example-archive/c-testsuite/working/00118.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00118.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00118.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00118.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00120.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00120.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00120.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00120.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00121.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00121.working.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: f -- pass
+[2/3]: g -- pass
+[3/3]: main -- pass

--- a/src/example-archive/c-testsuite/working/00121.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00121.working.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: f -- pass
+[2/3]: g -- pass
+[3/3]: main -- pass

--- a/src/example-archive/c-testsuite/working/00122.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00122.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00122.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00122.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00126.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00126.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00126.c.z3
+++ b/src/example-archive/c-testsuite/working/00126.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00128.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00128.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00128.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00128.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00129.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00129.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00129.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00129.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00134.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00134.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00134.c.z3
+++ b/src/example-archive/c-testsuite/working/00134.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00135.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00135.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00135.c.z3
+++ b/src/example-archive/c-testsuite/working/00135.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00136.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00136.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00136.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00136.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00139.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00139.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00139.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00139.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00145.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00145.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00145.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00145.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00146.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00146.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00146.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00146.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00152.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00152.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00152.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00152.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00153.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00153.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00153.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00153.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00155.working.c.cvc5
+++ b/src/example-archive/c-testsuite/working/00155.working.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/c-testsuite/working/00155.working.c.z3
+++ b/src/example-archive/c-testsuite/working/00155.working.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: main -- pass

--- a/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-005.c.cvc5
+++ b/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-005.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-005.c.z3
+++ b/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-005.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-006.c.cvc5
+++ b/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-006.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-006.c.z3
+++ b/src/example-archive/coq-lemmas/broken/error-cerberus/trivial-006.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/coq/broken-export/recursive-001.c.cvc5
+++ b/src/example-archive/coq-lemmas/coq/broken-export/recursive-001.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: factorial -- pass

--- a/src/example-archive/coq-lemmas/coq/broken-export/recursive-001.c.z3
+++ b/src/example-archive/coq-lemmas/coq/broken-export/recursive-001.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: factorial -- pass

--- a/src/example-archive/coq-lemmas/coq/broken-export/recursive-002.c.cvc5
+++ b/src/example-archive/coq-lemmas/coq/broken-export/recursive-002.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: fibonacci -- pass

--- a/src/example-archive/coq-lemmas/coq/broken-export/recursive-002.c.z3
+++ b/src/example-archive/coq-lemmas/coq/broken-export/recursive-002.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: fibonacci -- pass

--- a/src/example-archive/coq-lemmas/coq/working/trivial-001.c.cvc5
+++ b/src/example-archive/coq-lemmas/coq/working/trivial-001.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: lemma_1 -- pass

--- a/src/example-archive/coq-lemmas/coq/working/trivial-001.c.z3
+++ b/src/example-archive/coq-lemmas/coq/working/trivial-001.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: lemma_1 -- pass

--- a/src/example-archive/coq-lemmas/coq/working/trivial-003.c.cvc5
+++ b/src/example-archive/coq-lemmas/coq/working/trivial-003.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/coq/working/trivial-003.c.z3
+++ b/src/example-archive/coq-lemmas/coq/working/trivial-003.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/inprogress/trivial-007.c.cvc5
+++ b/src/example-archive/coq-lemmas/inprogress/trivial-007.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/coq-lemmas/inprogress/trivial-007.c:3:3: error: Non-pointer first input argument
+  predicate (boolean) MyCondition (u32 x){
+  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+the first input argument of predicate 'MyCondition' must have type 'pointer' but was found with type 'u32'

--- a/src/example-archive/coq-lemmas/inprogress/trivial-007.c.z3
+++ b/src/example-archive/coq-lemmas/inprogress/trivial-007.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/coq-lemmas/inprogress/trivial-007.c:3:3: error: Non-pointer first input argument
+  predicate (boolean) MyCondition (u32 x){
+  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+the first input argument of predicate 'MyCondition' must have type 'pointer' but was found with type 'u32'

--- a/src/example-archive/coq-lemmas/inprogress/trivial-008.c.cvc5
+++ b/src/example-archive/coq-lemmas/inprogress/trivial-008.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/inprogress/trivial-008.c.z3
+++ b/src/example-archive/coq-lemmas/inprogress/trivial-008.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: trivial -- pass

--- a/src/example-archive/coq-lemmas/inprogress/trivial-009.c.cvc5
+++ b/src/example-archive/coq-lemmas/inprogress/trivial-009.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: factorial -- pass

--- a/src/example-archive/coq-lemmas/inprogress/trivial-009.c.z3
+++ b/src/example-archive/coq-lemmas/inprogress/trivial-009.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: factorial -- pass

--- a/src/example-archive/dafny-tutorial/broken/error-proof/fib.c.cvc5
+++ b/src/example-archive/dafny-tutorial/broken/error-proof/fib.c.cvc5
@@ -1,0 +1,8 @@
+return code: 1
+./src/example-archive/dafny-tutorial/broken/error-proof/fib.c:21:19: error: Type error
+/*@ requires 0 <= n; @*/
+                  ^
+Expression 'n' has type 'i32'.
+I expected it to have type 'integer' because of ./src/example-archive/dafny-tutorial/broken/error-proof/fib.c:21:14:
+/*@ requires 0 <= n; @*/
+             ^

--- a/src/example-archive/dafny-tutorial/broken/error-proof/fib.c.z3
+++ b/src/example-archive/dafny-tutorial/broken/error-proof/fib.c.z3
@@ -1,0 +1,8 @@
+return code: 1
+./src/example-archive/dafny-tutorial/broken/error-proof/fib.c:21:19: error: Type error
+/*@ requires 0 <= n; @*/
+                  ^
+Expression 'n' has type 'i32'.
+I expected it to have type 'integer' because of ./src/example-archive/dafny-tutorial/broken/error-proof/fib.c:21:14:
+/*@ requires 0 <= n; @*/
+             ^

--- a/src/example-archive/dafny-tutorial/working/abs_1.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/abs_1.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: abs -- pass
+[2/2]: abs_testing -- pass

--- a/src/example-archive/dafny-tutorial/working/abs_1.c.z3
+++ b/src/example-archive/dafny-tutorial/working/abs_1.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: abs -- pass
+[2/2]: abs_testing -- pass

--- a/src/example-archive/dafny-tutorial/working/abs_2.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/abs_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs_2 -- pass

--- a/src/example-archive/dafny-tutorial/working/abs_2.c.z3
+++ b/src/example-archive/dafny-tutorial/working/abs_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs_2 -- pass

--- a/src/example-archive/dafny-tutorial/working/abs_3.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/abs_3.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs_3 -- pass

--- a/src/example-archive/dafny-tutorial/working/abs_3.c.z3
+++ b/src/example-archive/dafny-tutorial/working/abs_3.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs_3 -- pass

--- a/src/example-archive/dafny-tutorial/working/binary_search.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/binary_search.c.cvc5
@@ -1,0 +1,19 @@
+return code: 0
+./src/example-archive/dafny-tutorial/working/binary_search.c:10:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPre = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/binary_search.c:13:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPost = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/binary_search.c:28:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+./src/example-archive/dafny-tutorial/working/binary_search.c:28:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&mid0' with type 'i32' was provided. This will become an error in the future.
+
+./src/example-archive/dafny-tutorial/working/binary_search.c:34:9: warning: nothing instantiated
+    /*@ instantiate good<int>, mid;  @*/
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+[1/1]: binary_search -- pass

--- a/src/example-archive/dafny-tutorial/working/binary_search.c.z3
+++ b/src/example-archive/dafny-tutorial/working/binary_search.c.z3
@@ -1,0 +1,19 @@
+return code: 0
+./src/example-archive/dafny-tutorial/working/binary_search.c:10:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPre = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/binary_search.c:13:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPost = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/binary_search.c:28:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+./src/example-archive/dafny-tutorial/working/binary_search.c:28:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&mid0' with type 'i32' was provided. This will become an error in the future.
+
+./src/example-archive/dafny-tutorial/working/binary_search.c:34:9: warning: nothing instantiated
+    /*@ instantiate good<int>, mid;  @*/
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+[1/1]: binary_search -- pass

--- a/src/example-archive/dafny-tutorial/working/linear_search.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/linear_search.c.cvc5
@@ -1,0 +1,16 @@
+return code: 0
+./src/example-archive/dafny-tutorial/working/linear_search.c:6:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPre = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/linear_search.c:9:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPost = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/linear_search.c:23:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+./src/example-archive/dafny-tutorial/working/linear_search.c:23:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&idx0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: linear_search -- pass

--- a/src/example-archive/dafny-tutorial/working/linear_search.c.z3
+++ b/src/example-archive/dafny-tutorial/working/linear_search.c.z3
@@ -1,0 +1,16 @@
+return code: 0
+./src/example-archive/dafny-tutorial/working/linear_search.c:6:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPre = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/linear_search.c:9:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take IndexPost = each (i32 j; 0i32 <= j && j < length)
+           ^
+./src/example-archive/dafny-tutorial/working/linear_search.c:23:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+./src/example-archive/dafny-tutorial/working/linear_search.c:23:14: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+        take IndexInv = each (i32 j; 0i32 <= j && j < length)
+             ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&idx0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: linear_search -- pass

--- a/src/example-archive/dafny-tutorial/working/max.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/max.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: max -- pass
+[2/2]: max_test -- pass

--- a/src/example-archive/dafny-tutorial/working/max.c.z3
+++ b/src/example-archive/dafny-tutorial/working/max.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: max -- pass
+[2/2]: max_test -- pass

--- a/src/example-archive/dafny-tutorial/working/multiple_returns.c.cvc5
+++ b/src/example-archive/dafny-tutorial/working/multiple_returns.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: multiple_returns -- pass

--- a/src/example-archive/dafny-tutorial/working/multiple_returns.c.z3
+++ b/src/example-archive/dafny-tutorial/working/multiple_returns.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: multiple_returns -- pass

--- a/src/example-archive/java_program_verification_challenges/broken/error-cerberus/00008_overload_dyn_method.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-cerberus/00008_overload_dyn_method.c.cvc5
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/java_program_verification_challenges/broken/error-cerberus/00008_overload_dyn_method.c:42:21: error: feature not yet supported: TODO: Tspec_name, not resolved
+    take pv = Owned<Point>(p);
+                    ^

--- a/src/example-archive/java_program_verification_challenges/broken/error-cerberus/00008_overload_dyn_method.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-cerberus/00008_overload_dyn_method.c.z3
@@ -1,0 +1,4 @@
+return code: 2
+./src/example-archive/java_program_verification_challenges/broken/error-cerberus/00008_overload_dyn_method.c:42:21: error: feature not yet supported: TODO: Tspec_name, not resolved
+    take pv = Owned<Point>(p);
+                    ^

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c.cvc5
@@ -1,0 +1,12 @@
+return code: 1
+[1/3]: createC -- fail
+[2/3]: m -- fail
+[3/3]: main -- pass
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c:18:17: error: Unknown function 'malloc_proxy'
+    C* c = (C*) malloc(sizeof(C)); // Allocate memory for C
+                ^~~~~~ 
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c:36:5: error: Pointer `call_createC0.return` needs allocation ID
+    c->a = c;         // Alias to itself
+    ~^~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00001_aliasing.c__m.html

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c.z3
@@ -1,0 +1,12 @@
+return code: 1
+[1/3]: createC -- fail
+[2/3]: m -- fail
+[3/3]: main -- pass
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c:18:17: error: Unknown function 'malloc_proxy'
+    C* c = (C*) malloc(sizeof(C)); // Allocate memory for C
+                ^~~~~~ 
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00001_aliasing.c:36:5: error: Pointer `call_createC0.return` needs allocation ID
+    c->a = c;         // Alias to itself
+    ~^~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00001_aliasing.c__m.html

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00002_side_effects.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00002_side_effects.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00002_side_effects.c:63:33: error: unexpected token after 'bool' and before 'bool'
+parsing "typedef_name": seen "LNAME", expecting "TYPE"
+  /*@ requires take vr0 = Block<bool>(result1);
+                                ^~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00002_side_effects.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00002_side_effects.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00002_side_effects.c:63:33: error: unexpected token after 'bool' and before 'bool'
+parsing "typedef_name": seen "LNAME", expecting "TYPE"
+  /*@ requires take vr0 = Block<bool>(result1);
+                                ^~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00003_break.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00003_break.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00003_break.c:57:7: error: unexpected token after ')' and before 'ensures'
+parsing "condition": seen "CN_TAKE LNAME VARIABLE EQ resource", expecting "SEMICOLON"
+      ensures take vp1 = Owned<int>(&ia_length)
+      ^~~~~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00003_break.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00003_break.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00003_break.c:57:7: error: unexpected token after ')' and before 'ensures'
+parsing "condition": seen "CN_TAKE LNAME VARIABLE EQ resource", expecting "SEMICOLON"
+      ensures take vp1 = Owned<int>(&ia_length)
+      ^~~~~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00005_bit_switch.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00005_bit_switch.c.cvc5
@@ -1,0 +1,8 @@
+return code: 1
+[1/2]: select_mode -- fail
+[2/2]: main -- pass
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00005_bit_switch.c:59:21: error: Missing resource for writing
+                    mode = ACTION_ONE;
+                    ~~~~~^~~ 
+Resource needed: Block<unsigned ichar>(&mode)
+State file: file:///tmp/state__00005_bit_switch.c__select_mode.html

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00005_bit_switch.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00005_bit_switch.c.z3
@@ -1,0 +1,8 @@
+return code: 1
+[1/2]: select_mode -- fail
+[2/2]: main -- pass
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00005_bit_switch.c:59:21: error: Missing resource for writing
+                    mode = ACTION_ONE;
+                    ~~~~~^~~ 
+Resource needed: Block<unsigned ichar>(&mode)
+State file: file:///tmp/state__00005_bit_switch.c__select_mode.html

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00006_callbacks.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00006_callbacks.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00006_callbacks.c:79:7: error: unexpected token after '0i32' and before 'ensures'
+Please add error message for state 1079 to parsers/c/c_parser_error.messages
+      ensures take va1 = Owned<A>(a);
+      ^~~~~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00006_callbacks.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00006_callbacks.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00006_callbacks.c:79:7: error: unexpected token after '0i32' and before 'ensures'
+Please add error message for state 1079 to parsers/c/c_parser_error.messages
+      ensures take va1 = Owned<A>(a);
+      ^~~~~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00007_static_init.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00007_static_init.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00007_static_init.c:81:34: error: unexpected token after 'bool' and before 'bool'
+parsing "typedef_name": seen "LNAME", expecting "TYPE"
+  /*@ requires take vbl0 = Owned<bool>(bl);
+                                 ^~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00007_static_init.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00007_static_init.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00007_static_init.c:81:34: error: unexpected token after 'bool' and before 'bool'
+parsing "typedef_name": seen "LNAME", expecting "TYPE"
+  /*@ requires take vbl0 = Owned<bool>(bl);
+                                 ^~~~ 

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c.z3
+++ b/src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c.z3
@@ -1,0 +1,16 @@
+return code: 1
+[1/3]: iabs -- fail
+[2/3]: isqrt -- fail
+[3/3]: main -- pass
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c:52:23: error: Undefined behaviour
+    if (x < 0) return -x;
+                      ^~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__00011_dependen_specifications.c__iabs.html
+./src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c:76:5: error: Unprovable constraint
+    while (sum <= x)
+    ^~~~~~~~~~~~~~~~ 
+Constraint from ./src/example-archive/java_program_verification_challenges/broken/error-proof/00011_dependen_specifications.c:81:6:
+	    sum <= x + 2i32 *count+1i32; 
+	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__00011_dependen_specifications.c__isqrt.html

--- a/src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c.cvc5
@@ -1,0 +1,16 @@
+return code: 1
+[1/5]: generic_m -- fail
+[2/5]: C_m -- pass
+[3/5]: Inheritance_m -- pass
+[4/5]: Inheritance_test -- fail
+[5/5]: main -- pass
+./src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c:76:20: error: Pointer `instance.object` needs allocation ID
+            return ((C*)instance.object)->m(instance);
+                   ~~~~~~~~~~~~~~~~~~~~~^~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00009_inheritance.c__generic_m.html
+./src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c:99:16: error: Pointer `instance.object` needs allocation ID
+        return ((Inheritance*)instance.object)->base.m(instance);
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00009_inheritance.c__Inheritance_test.html

--- a/src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c.z3
+++ b/src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c.z3
@@ -1,0 +1,16 @@
+return code: 1
+[1/5]: generic_m -- fail
+[2/5]: C_m -- pass
+[3/5]: Inheritance_m -- pass
+[4/5]: Inheritance_test -- fail
+[5/5]: main -- pass
+./src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c:76:20: error: Pointer `instance.object` needs allocation ID
+            return ((C*)instance.object)->m(instance);
+                   ~~~~~~~~~~~~~~~~~~~~~^~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00009_inheritance.c__generic_m.html
+./src/example-archive/java_program_verification_challenges/inprogress/00009_inheritance.c:99:16: error: Pointer `instance.object` needs allocation ID
+        return ((Inheritance*)instance.object)->base.m(instance);
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__00009_inheritance.c__Inheritance_test.html

--- a/src/example-archive/java_program_verification_challenges/working/00004_exceptions.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/working/00004_exceptions.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: returnfinally -- pass
+[2/2]: main -- pass

--- a/src/example-archive/java_program_verification_challenges/working/00004_exceptions.c.z3
+++ b/src/example-archive/java_program_verification_challenges/working/00004_exceptions.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: returnfinally -- pass
+[2/2]: main -- pass

--- a/src/example-archive/java_program_verification_challenges/working/00010_non_termination.c.cvc5
+++ b/src/example-archive/java_program_verification_challenges/working/00010_non_termination.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: m -- pass
+[2/2]: main -- pass

--- a/src/example-archive/java_program_verification_challenges/working/00010_non_termination.c.z3
+++ b/src/example-archive/java_program_verification_challenges/working/00010_non_termination.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: m -- pass
+[2/2]: main -- pass

--- a/src/example-archive/open-sut/broken/error-proof/instrumentation_impl.c.cvc5
+++ b/src/example-archive/open-sut/broken/error-proof/instrumentation_impl.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/3]: Trip -- fail
+[2/3]: Generate_Sensor_Trips -- pass
+[3/3]: Is_Ch_Tripped -- pass
+./src/example-archive/open-sut/broken/error-proof/instrumentation_impl.c:22:17: error: Pointer `setpoints` needs allocation ID
+        return (setpoints[ch] < vals[ch]);
+                ^~~~~~~~~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__instrumentation_impl.c__Trip.html

--- a/src/example-archive/open-sut/broken/error-proof/instrumentation_impl.c.z3
+++ b/src/example-archive/open-sut/broken/error-proof/instrumentation_impl.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/3]: Trip -- fail
+[2/3]: Generate_Sensor_Trips -- pass
+[3/3]: Is_Ch_Tripped -- pass
+./src/example-archive/open-sut/broken/error-proof/instrumentation_impl.c:22:17: error: Pointer `setpoints` needs allocation ID
+        return (setpoints[ch] < vals[ch]);
+                ^~~~~~~~~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__instrumentation_impl.c__Trip.html

--- a/src/example-archive/open-sut/working/mps_1.c.cvc5
+++ b/src/example-archive/open-sut/working/mps_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: Coincidence_2_4 -- pass

--- a/src/example-archive/open-sut/working/mps_1.c.z3
+++ b/src/example-archive/open-sut/working/mps_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: Coincidence_2_4 -- pass

--- a/src/example-archive/should-fail/broken/error-proof/arith_neg_1.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/arith_neg_1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: arith_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/arith_neg_1.c:8:3: error: Unprovable constraint
+  return 0; 
+  ^~~~~~~~~ 
+Constraint from ./src/example-archive/should-fail/broken/error-proof/arith_neg_1.c:6:13:
+/*@ ensures return != 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__arith_neg_1.c__arith_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/arith_neg_1.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/arith_neg_1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: arith_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/arith_neg_1.c:8:3: error: Unprovable constraint
+  return 0; 
+  ^~~~~~~~~ 
+Constraint from ./src/example-archive/should-fail/broken/error-proof/arith_neg_1.c:6:13:
+/*@ ensures return != 0i32; @*/
+            ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__arith_neg_1.c__arith_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/memory_neg_1.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/memory_neg_1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: memory_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/memory_neg_1.c:7:3: error: Missing resource for writing
+  *p = 1; 
+  ~~~^~~ 
+Resource needed: Block<signed int>(p)
+State file: file:///tmp/state__memory_neg_1.c__memory_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/memory_neg_1.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/memory_neg_1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: memory_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/memory_neg_1.c:7:3: error: Missing resource for writing
+  *p = 1; 
+  ~~~^~~ 
+Resource needed: Block<signed int>(p)
+State file: file:///tmp/state__memory_neg_1.c__memory_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/overflow_neg_1.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/overflow_neg_1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: overflow_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/overflow_neg_1.c:8:7: error: Undefined behaviour
+  i = i + 1; 
+      ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__overflow_neg_1.c__overflow_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/overflow_neg_1.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/overflow_neg_1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: overflow_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/overflow_neg_1.c:8:7: error: Undefined behaviour
+  i = i + 1; 
+      ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__overflow_neg_1.c__overflow_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/overflow_neg_2.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/overflow_neg_2.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: overflow_neg_2 -- fail
+./src/example-archive/should-fail/broken/error-proof/overflow_neg_2.c:8:7: error: Undefined behaviour
+  i = i - 1; 
+      ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__overflow_neg_2.c__overflow_neg_2.html

--- a/src/example-archive/should-fail/broken/error-proof/overflow_neg_2.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/overflow_neg_2.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: overflow_neg_2 -- fail
+./src/example-archive/should-fail/broken/error-proof/overflow_neg_2.c:8:7: error: Undefined behaviour
+  i = i - 1; 
+      ~~^~~ 
+an exceptional condition occurs during the evaluation of an expression (§6.5#5)
+State file: file:///tmp/state__overflow_neg_2.c__overflow_neg_2.html

--- a/src/example-archive/should-fail/broken/error-proof/ownership_neg_1.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/ownership_neg_1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: ownership_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/ownership_neg_1.c:5:1: error: Left-over unused resource 'Owned<signed int>(p)(P)'
+void ownership_neg_1(int *p) 
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ownership_neg_1.c__ownership_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/ownership_neg_1.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/ownership_neg_1.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: ownership_neg_1 -- fail
+./src/example-archive/should-fail/broken/error-proof/ownership_neg_1.c:5:1: error: Left-over unused resource 'Owned<signed int>(p)(P)'
+void ownership_neg_1(int *p) 
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ownership_neg_1.c__ownership_neg_1.html

--- a/src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c.cvc5
@@ -1,0 +1,8 @@
+return code: 1
+[1/1]: ownership_neg_2 -- fail
+./src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c:5:1: error: Missing resource for returning
+void ownership_neg_2(int *p) 
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(p)
+      ./src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c:7:18: (arg P_)
+State file: file:///tmp/state__ownership_neg_2.c__ownership_neg_2.html

--- a/src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c.z3
@@ -1,0 +1,8 @@
+return code: 1
+[1/1]: ownership_neg_2 -- fail
+./src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c:5:1: error: Missing resource for returning
+void ownership_neg_2(int *p) 
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(p)
+      ./src/example-archive/should-fail/broken/error-proof/ownership_neg_2.c:7:18: (arg P_)
+State file: file:///tmp/state__ownership_neg_2.c__ownership_neg_2.html

--- a/src/example-archive/should-fail/broken/error-proof/ownership_neg_3.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/ownership_neg_3.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/should-fail/broken/error-proof/ownership_neg_3.c:5:1: error: return type makes inconsistent assumptions
+void ownership_neg_3(int *p) 
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ownership_neg_3.c.html

--- a/src/example-archive/should-fail/broken/error-proof/ownership_neg_3.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/ownership_neg_3.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/should-fail/broken/error-proof/ownership_neg_3.c:5:1: error: return type makes inconsistent assumptions
+void ownership_neg_3(int *p) 
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ownership_neg_3.c.html

--- a/src/example-archive/should-fail/broken/error-proof/trivial_neg_1.c.cvc5
+++ b/src/example-archive/should-fail/broken/error-proof/trivial_neg_1.c.cvc5
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/should-fail/broken/error-proof/trivial_neg_1.c:4:1: error: return type makes inconsistent assumptions
+void trivial_neg_1() 
+~~~~~^~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__trivial_neg_1.c.html

--- a/src/example-archive/should-fail/broken/error-proof/trivial_neg_1.c.z3
+++ b/src/example-archive/should-fail/broken/error-proof/trivial_neg_1.c.z3
@@ -1,0 +1,5 @@
+return code: 1
+./src/example-archive/should-fail/broken/error-proof/trivial_neg_1.c:4:1: error: return type makes inconsistent assumptions
+void trivial_neg_1() 
+~~~~~^~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__trivial_neg_1.c.html

--- a/src/example-archive/should-fail/working/c_sequencing_race.c.cvc5
+++ b/src/example-archive/should-fail/working/c_sequencing_race.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: f -- pass

--- a/src/example-archive/should-fail/working/c_sequencing_race.c.z3
+++ b/src/example-archive/should-fail/working/c_sequencing_race.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: f -- pass

--- a/src/example-archive/should-fail/working/letweak01.c.cvc5
+++ b/src/example-archive/should-fail/working/letweak01.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: f -- pass

--- a/src/example-archive/should-fail/working/letweak01.c.z3
+++ b/src/example-archive/should-fail/working/letweak01.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: f -- pass

--- a/src/example-archive/simple-examples/broken/error-cerberus/pred_1.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-cerberus/pred_1.c.cvc5
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/simple-examples/broken/error-cerberus/pred_1.c:7:3: error: unexpected token after ';' and before 'if'
+parsing "clause": seen "CN_TAKE UNAME VARIABLE EQ resource SEMICOLON", expecting "clause"
+  if (PVal == 0i32) {
+  ^~ 

--- a/src/example-archive/simple-examples/broken/error-cerberus/pred_1.c.z3
+++ b/src/example-archive/simple-examples/broken/error-cerberus/pred_1.c.z3
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/simple-examples/broken/error-cerberus/pred_1.c:7:3: error: unexpected token after ';' and before 'if'
+parsing "clause": seen "CN_TAKE UNAME VARIABLE EQ resource SEMICOLON", expecting "clause"
+  if (PVal == 0i32) {
+  ^~ 

--- a/src/example-archive/simple-examples/broken/error-crash/array_crash_2.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-crash/array_crash_2.c.cvc5
@@ -1,0 +1,12 @@
+return code: 125
+unsupported: ./src/example-archive/simple-examples/broken/error-crash/array_crash_2.c:4:13:: GCC statements as expressions not yet supported
+internal error: ./src/example-archive/simple-examples/broken/error-crash/array_crash_2.c:4:13:: GCC statements as expressions not yet supported
+cn: internal error, uncaught exception:
+    Failure("internal error: ./src/example-archive/simple-examples/broken/error-crash/array_crash_2.c:4:13:: GCC statements as expressions not yet supported")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Translation.translate in file "ocaml_frontend/generated/translation.ml", line 4452, characters 4-92
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration.(fun) in file "backend/common/pipeline.ml", line 245, characters 18-92
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/simple-examples/broken/error-crash/array_crash_2.c.z3
+++ b/src/example-archive/simple-examples/broken/error-crash/array_crash_2.c.z3
@@ -1,0 +1,12 @@
+return code: 125
+unsupported: ./src/example-archive/simple-examples/broken/error-crash/array_crash_2.c:4:13:: GCC statements as expressions not yet supported
+internal error: ./src/example-archive/simple-examples/broken/error-crash/array_crash_2.c:4:13:: GCC statements as expressions not yet supported
+cn: internal error, uncaught exception:
+    Failure("internal error: ./src/example-archive/simple-examples/broken/error-crash/array_crash_2.c:4:13:: GCC statements as expressions not yet supported")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Translation.translate in file "ocaml_frontend/generated/translation.ml", line 4452, characters 4-92
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration.(fun) in file "backend/common/pipeline.ml", line 245, characters 18-92
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/simple-examples/broken/error-crash/array_crash_3.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-crash/array_crash_3.c.cvc5
@@ -1,0 +1,28 @@
+return code: 125
+internal error: TODO: do_next_in_same_level _
+cn: internal error, uncaught exception:
+    Failure("internal error: TODO: do_next_in_same_level _")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Desugaring_init.interp_initializer_aux.(fun) in file "ocaml_frontend/generated/desugaring_init.ml", line 511, characters 22-59
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.state_except_eval.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 94, characters 94-99
+    Called from Cerb_backend__Pipeline.c_frontend.desugar in file "backend/common/pipeline.ml", lines 191-192, characters 4-23
+    Called from Cerb_backend__Pipeline.c_frontend.(fun) in file "backend/common/pipeline.ml", line 233, characters 2-20
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration in file "backend/common/pipeline.ml", line 238, characters 2-73
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/simple-examples/broken/error-crash/array_crash_3.c.z3
+++ b/src/example-archive/simple-examples/broken/error-crash/array_crash_3.c.z3
@@ -1,0 +1,28 @@
+return code: 125
+internal error: TODO: do_next_in_same_level _
+cn: internal error, uncaught exception:
+    Failure("internal error: TODO: do_next_in_same_level _")
+    Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+    Called from Cerb_frontend__Desugaring_init.interp_initializer_aux.(fun) in file "ocaml_frontend/generated/desugaring_init.ml", line 511, characters 22-59
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.stExpect_bind.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 19, characters 24-29
+    Called from Cerb_frontend__State_exception.state_except_eval.(fun) in file "ocaml_frontend/generated/state_exception.ml", line 94, characters 94-99
+    Called from Cerb_backend__Pipeline.c_frontend.desugar in file "backend/common/pipeline.ml", lines 191-192, characters 4-23
+    Called from Cerb_backend__Pipeline.c_frontend.(fun) in file "backend/common/pipeline.ml", line 233, characters 2-20
+    Called from Cerb_backend__Pipeline.c_frontend_and_elaboration in file "backend/common/pipeline.ml", line 238, characters 2-73
+    Called from Dune__exe__Main.frontend in file "backend/cn/bin/main.ml", line 77, characters 4-81
+    Called from Dune__exe__Main.with_well_formedness_check in file "backend/cn/bin/main.ml", lines 144-150, characters 6-36
+    Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+    Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44

--- a/src/example-archive/simple-examples/broken/error-proof/loop_4.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-proof/loop_4.c.cvc5
@@ -1,0 +1,10 @@
+return code: 1
+[1/3]: loop_4 -- fail
+[2/3]: loop_4_unrolled -- pass
+[3/3]: loop_4_with_redundant_write -- pass
+./src/example-archive/simple-examples/broken/error-proof/loop_4.c:11:3: error: Missing resource for loop
+  while (i < 1) 
+  ^~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&t)
+      ./src/example-archive/simple-examples/broken/error-proof/loop_4.c:11:3: (arg O_t0)
+State file: file:///tmp/state__loop_4.c__loop_4.html

--- a/src/example-archive/simple-examples/broken/error-proof/loop_4.c.z3
+++ b/src/example-archive/simple-examples/broken/error-proof/loop_4.c.z3
@@ -1,0 +1,10 @@
+return code: 1
+[1/3]: loop_4 -- fail
+[2/3]: loop_4_unrolled -- pass
+[3/3]: loop_4_with_redundant_write -- pass
+./src/example-archive/simple-examples/broken/error-proof/loop_4.c:11:3: error: Missing resource for loop
+  while (i < 1) 
+  ^~~~~~~~~~~~~~ 
+Resource needed: Owned<signed int>(&t)
+      ./src/example-archive/simple-examples/broken/error-proof/loop_4.c:11:3: (arg O_t0)
+State file: file:///tmp/state__loop_4.c__loop_4.html

--- a/src/example-archive/simple-examples/broken/error-proof/ownership_1.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-proof/ownership_1.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+./src/example-archive/simple-examples/broken/error-proof/ownership_1.c:14:18: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+  /*@ split_case a == b; @*/
+                 ~~^~~~ 
+[1/1]: ownership_1 -- fail
+./src/example-archive/simple-examples/broken/error-proof/ownership_1.c:5:1: error: Left-over unused resource 'Owned<signed int>(b)(P2)'
+void ownership_1(int *a, int *b)
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ownership_1.c__ownership_1.html

--- a/src/example-archive/simple-examples/broken/error-proof/ownership_1.c.z3
+++ b/src/example-archive/simple-examples/broken/error-proof/ownership_1.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+./src/example-archive/simple-examples/broken/error-proof/ownership_1.c:14:18: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+  /*@ split_case a == b; @*/
+                 ~~^~~~ 
+[1/1]: ownership_1 -- fail
+./src/example-archive/simple-examples/broken/error-proof/ownership_1.c:5:1: error: Left-over unused resource 'Owned<signed int>(b)(P2)'
+void ownership_1(int *a, int *b)
+~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ownership_1.c__ownership_1.html

--- a/src/example-archive/simple-examples/broken/error-proof/pointer_dec3.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-proof/pointer_dec3.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: pointerdec_crash_3 -- fail
+./src/example-archive/simple-examples/broken/error-proof/pointer_dec3.c:8:3: error: Missing resource for reading
+  *(--p); 
+  ^~~~~~ 
+Resource needed: Owned<signed int>(&(&&arr[1'u64])[(u64)(0'i32 - 1'i32)])
+State file: file:///tmp/state__pointer_dec3.c__pointerdec_crash_3.html

--- a/src/example-archive/simple-examples/broken/error-proof/pointer_dec3.c.z3
+++ b/src/example-archive/simple-examples/broken/error-proof/pointer_dec3.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: pointerdec_crash_3 -- fail
+./src/example-archive/simple-examples/broken/error-proof/pointer_dec3.c:8:3: error: Missing resource for reading
+  *(--p); 
+  ^~~~~~ 
+Resource needed: Owned<signed int>(&(&&arr[1'u64])[(u64)(0'i32 - 1'i32)])
+State file: file:///tmp/state__pointer_dec3.c__pointerdec_crash_3.html

--- a/src/example-archive/simple-examples/broken/error-proof/self_ref_init.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-proof/self_ref_init.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: f -- fail
+./src/example-archive/simple-examples/broken/error-proof/self_ref_init.c:14:10: error: Missing resource for reading
+    .y = str_inst.x + 3,
+         ~~~~~~~~^~ 
+Resource needed: Owned<signed int>(&&str_inst->x)
+State file: file:///tmp/state__self_ref_init.c__f.html

--- a/src/example-archive/simple-examples/broken/error-proof/self_ref_init.c.z3
+++ b/src/example-archive/simple-examples/broken/error-proof/self_ref_init.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: f -- fail
+./src/example-archive/simple-examples/broken/error-proof/self_ref_init.c:14:10: error: Missing resource for reading
+    .y = str_inst.x + 3,
+         ~~~~~~~~^~ 
+Resource needed: Owned<signed int>(&&str_inst->x)
+State file: file:///tmp/state__self_ref_init.c__f.html

--- a/src/example-archive/simple-examples/broken/error-proof/shift_crash_1.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-proof/shift_crash_1.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: a -- fail
+./src/example-archive/simple-examples/broken/error-proof/shift_crash_1.c:5:1: error: Undefined behaviour
+uint8_t a(uint32_t b, uint32_t c, uint8_t ch) { a(b, c, 1) << 1; }
+~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+the value of a non-void function that ended without a return statement is used
+State file: file:///tmp/state__shift_crash_1.c__a.html

--- a/src/example-archive/simple-examples/broken/error-proof/shift_crash_1.c.z3
+++ b/src/example-archive/simple-examples/broken/error-proof/shift_crash_1.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: a -- fail
+./src/example-archive/simple-examples/broken/error-proof/shift_crash_1.c:5:1: error: Undefined behaviour
+uint8_t a(uint32_t b, uint32_t c, uint8_t ch) { a(b, c, 1) << 1; }
+~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+the value of a non-void function that ended without a return statement is used
+State file: file:///tmp/state__shift_crash_1.c__a.html

--- a/src/example-archive/simple-examples/broken/error-proof/sizeof_1.c.cvc5
+++ b/src/example-archive/simple-examples/broken/error-proof/sizeof_1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/simple-examples/broken/error-proof/sizeof_1.c:10:14: error: Mismatched types.
+	int size2 = sizeof(int) + 1; // <- fails 
+	            ~~~~~~~~~~~~^~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/simple-examples/broken/error-proof/sizeof_1.c.z3
+++ b/src/example-archive/simple-examples/broken/error-proof/sizeof_1.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: main -- fail
+./src/example-archive/simple-examples/broken/error-proof/sizeof_1.c:10:14: error: Mismatched types.
+	int size2 = sizeof(int) + 1; // <- fails 
+	            ~~~~~~~~~~~~^~~ 
+Expected value of type 'u64' but found value of type 'u32'

--- a/src/example-archive/simple-examples/inprogress/power_3.c.cvc5
+++ b/src/example-archive/simple-examples/inprogress/power_3.c.cvc5
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/simple-examples/inprogress/power_3.c:8:3: error: unexpected token after 'i' and before 'ensures'
+Please add error message for state 939 to parsers/c/c_parser_error.messages
+  ensures 
+  ^~~~~~~ 

--- a/src/example-archive/simple-examples/inprogress/power_3.c.z3
+++ b/src/example-archive/simple-examples/inprogress/power_3.c.z3
@@ -1,0 +1,5 @@
+return code: 2
+./src/example-archive/simple-examples/inprogress/power_3.c:8:3: error: unexpected token after 'i' and before 'ensures'
+Please add error message for state 939 to parsers/c/c_parser_error.messages
+  ensures 
+  ^~~~~~~ 

--- a/src/example-archive/simple-examples/working/add_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/add_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_1 -- pass

--- a/src/example-archive/simple-examples/working/add_1.c.z3
+++ b/src/example-archive/simple-examples/working/add_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_1 -- pass

--- a/src/example-archive/simple-examples/working/add_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/add_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_2 -- pass

--- a/src/example-archive/simple-examples/working/add_2.c.z3
+++ b/src/example-archive/simple-examples/working/add_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_2 -- pass

--- a/src/example-archive/simple-examples/working/add_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/add_3.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_3 -- pass

--- a/src/example-archive/simple-examples/working/add_3.c.z3
+++ b/src/example-archive/simple-examples/working/add_3.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_3 -- pass

--- a/src/example-archive/simple-examples/working/add_4.c.cvc5
+++ b/src/example-archive/simple-examples/working/add_4.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: inc_1 -- pass

--- a/src/example-archive/simple-examples/working/add_4.c.z3
+++ b/src/example-archive/simple-examples/working/add_4.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: inc_1 -- pass

--- a/src/example-archive/simple-examples/working/add_5.c.cvc5
+++ b/src/example-archive/simple-examples/working/add_5.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_5 -- pass

--- a/src/example-archive/simple-examples/working/add_5.c.z3
+++ b/src/example-archive/simple-examples/working/add_5.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_5 -- pass

--- a/src/example-archive/simple-examples/working/add_uint_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/add_uint_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_uint_1 -- pass

--- a/src/example-archive/simple-examples/working/add_uint_1.c.z3
+++ b/src/example-archive/simple-examples/working/add_uint_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add_uint_1 -- pass

--- a/src/example-archive/simple-examples/working/array_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_1.c.cvc5
@@ -1,0 +1,10 @@
+return code: 0
+./src/example-archive/simple-examples/working/array_1.c:5:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayStart = each (i32 j; 0i32 <= j && j < size) {Owned(arr + j)}; 
+           ^
+./src/example-archive/simple-examples/working/array_1.c:8:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ ensures take arrayEnd = each (i32 j; 0i32 <= j && j < size) {Owned(arr + j)}; @*/
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_1 -- pass

--- a/src/example-archive/simple-examples/working/array_1.c.z3
+++ b/src/example-archive/simple-examples/working/array_1.c.z3
@@ -1,0 +1,10 @@
+return code: 0
+./src/example-archive/simple-examples/working/array_1.c:5:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayStart = each (i32 j; 0i32 <= j && j < size) {Owned(arr + j)}; 
+           ^
+./src/example-archive/simple-examples/working/array_1.c:8:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ ensures take arrayEnd = each (i32 j; 0i32 <= j && j < size) {Owned(arr + j)}; @*/
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_1 -- pass

--- a/src/example-archive/simple-examples/working/array_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_2.c.cvc5
@@ -1,0 +1,10 @@
+return code: 0
+./src/example-archive/simple-examples/working/array_2.c:5:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayStart = each (i32 j; 0i32  <= j && j < size) {Owned(arr + j)};
+           ^
+./src/example-archive/simple-examples/working/array_2.c:10:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayEnd = each (i32 j; 0i32  <= j && j < size) {Owned(arr + j)};
+           ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&off0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_2 -- pass

--- a/src/example-archive/simple-examples/working/array_2.c.z3
+++ b/src/example-archive/simple-examples/working/array_2.c.z3
@@ -1,0 +1,10 @@
+return code: 0
+./src/example-archive/simple-examples/working/array_2.c:5:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayStart = each (i32 j; 0i32  <= j && j < size) {Owned(arr + j)};
+           ^
+./src/example-archive/simple-examples/working/array_2.c:10:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayEnd = each (i32 j; 0i32  <= j && j < size) {Owned(arr + j)};
+           ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&off0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_2 -- pass

--- a/src/example-archive/simple-examples/working/array_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_3.c.cvc5
@@ -1,0 +1,16 @@
+return code: 0
+./src/example-archive/simple-examples/working/array_3.c:8:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayStart = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)}; @*/
+           ^
+./src/example-archive/simple-examples/working/array_3.c:10:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayEnd = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)};
+           ^
+./src/example-archive/simple-examples/working/array_3.c:19:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+          take arrayInv = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)};
+               ^
+./src/example-archive/simple-examples/working/array_3.c:19:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+          take arrayInv = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)};
+               ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_3 -- pass

--- a/src/example-archive/simple-examples/working/array_3.c.z3
+++ b/src/example-archive/simple-examples/working/array_3.c.z3
@@ -1,0 +1,16 @@
+return code: 0
+./src/example-archive/simple-examples/working/array_3.c:8:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayStart = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)}; @*/
+           ^
+./src/example-archive/simple-examples/working/array_3.c:10:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take arrayEnd = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)};
+           ^
+./src/example-archive/simple-examples/working/array_3.c:19:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+          take arrayInv = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)};
+               ^
+./src/example-archive/simple-examples/working/array_3.c:19:16: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+          take arrayInv = each (i32 j; 0i32 <= j && j < n) {Owned<int>(arr + j)};
+               ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_3 -- pass

--- a/src/example-archive/simple-examples/working/array_4.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_4.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/array_4.c.z3
+++ b/src/example-archive/simple-examples/working/array_4.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/array_5.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_5.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/array_5.c.z3
+++ b/src/example-archive/simple-examples/working/array_5.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/array_6.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_6.c.cvc5
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/example-archive/simple-examples/working/array_6.c.z3
+++ b/src/example-archive/simple-examples/working/array_6.c.z3
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/example-archive/simple-examples/working/array_read.c.cvc5
+++ b/src/example-archive/simple-examples/working/array_read.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: head -- pass

--- a/src/example-archive/simple-examples/working/array_read.c.z3
+++ b/src/example-archive/simple-examples/working/array_read.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: head -- pass

--- a/src/example-archive/simple-examples/working/assert_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/assert_1.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: assert_1 -- pass
+[2/2]: assert_1_alt -- pass

--- a/src/example-archive/simple-examples/working/assert_1.c.z3
+++ b/src/example-archive/simple-examples/working/assert_1.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: assert_1 -- pass
+[2/2]: assert_1_alt -- pass

--- a/src/example-archive/simple-examples/working/assert_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/assert_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: assert_2 -- pass

--- a/src/example-archive/simple-examples/working/assert_2.c.z3
+++ b/src/example-archive/simple-examples/working/assert_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: assert_2 -- pass

--- a/src/example-archive/simple-examples/working/assert_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/assert_3.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: assert_3 -- pass

--- a/src/example-archive/simple-examples/working/assert_3.c.z3
+++ b/src/example-archive/simple-examples/working/assert_3.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: assert_3 -- pass

--- a/src/example-archive/simple-examples/working/bit_compl_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/bit_compl_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/bit_compl_1.c.z3
+++ b/src/example-archive/simple-examples/working/bit_compl_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/cast_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/cast_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_1 -- pass

--- a/src/example-archive/simple-examples/working/cast_1.c.z3
+++ b/src/example-archive/simple-examples/working/cast_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_1 -- pass

--- a/src/example-archive/simple-examples/working/cast_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/cast_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_2 -- pass

--- a/src/example-archive/simple-examples/working/cast_2.c.z3
+++ b/src/example-archive/simple-examples/working/cast_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_2 -- pass

--- a/src/example-archive/simple-examples/working/cast_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/cast_3.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_3 -- pass

--- a/src/example-archive/simple-examples/working/cast_3.c.z3
+++ b/src/example-archive/simple-examples/working/cast_3.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_3 -- pass

--- a/src/example-archive/simple-examples/working/cast_4.c.cvc5
+++ b/src/example-archive/simple-examples/working/cast_4.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_4 -- pass

--- a/src/example-archive/simple-examples/working/cast_4.c.z3
+++ b/src/example-archive/simple-examples/working/cast_4.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cast_4 -- pass

--- a/src/example-archive/simple-examples/working/cn_function_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/cn_function_1.c.cvc5
@@ -1,0 +1,6 @@
+return code: 0
+./src/example-archive/simple-examples/working/cn_function_1.c:12:5: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+/*@ cn_function bw_or; @*/
+    ^~~~~~~~~~~ 
+[1/2]: c_bw_or -- pass
+[2/2]: cn_function_1 -- pass

--- a/src/example-archive/simple-examples/working/cn_function_1.c.z3
+++ b/src/example-archive/simple-examples/working/cn_function_1.c.z3
@@ -1,0 +1,6 @@
+return code: 0
+./src/example-archive/simple-examples/working/cn_function_1.c:12:5: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+/*@ cn_function bw_or; @*/
+    ^~~~~~~~~~~ 
+[1/2]: c_bw_or -- pass
+[2/2]: cn_function_1 -- pass

--- a/src/example-archive/simple-examples/working/cn_function_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/cn_function_2.c.cvc5
@@ -1,0 +1,6 @@
+return code: 0
+./src/example-archive/simple-examples/working/cn_function_2.c:11:5: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+/*@ cn_function bw_or_tern; @*/
+    ^~~~~~~~~~~ 
+[1/2]: c_bw_or_tern -- pass
+[2/2]: cn_function_2 -- pass

--- a/src/example-archive/simple-examples/working/cn_function_2.c.z3
+++ b/src/example-archive/simple-examples/working/cn_function_2.c.z3
@@ -1,0 +1,6 @@
+return code: 0
+./src/example-archive/simple-examples/working/cn_function_2.c:11:5: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+/*@ cn_function bw_or_tern; @*/
+    ^~~~~~~~~~~ 
+[1/2]: c_bw_or_tern -- pass
+[2/2]: cn_function_2 -- pass

--- a/src/example-archive/simple-examples/working/cond_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/cond_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cond_1 -- pass

--- a/src/example-archive/simple-examples/working/cond_1.c.z3
+++ b/src/example-archive/simple-examples/working/cond_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: cond_1 -- pass

--- a/src/example-archive/simple-examples/working/dec_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/dec_1.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: dec_1_pre -- pass
+[2/2]: dec_1_post -- pass

--- a/src/example-archive/simple-examples/working/dec_1.c.z3
+++ b/src/example-archive/simple-examples/working/dec_1.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: dec_1_pre -- pass
+[2/2]: dec_1_post -- pass

--- a/src/example-archive/simple-examples/working/division.c.cvc5
+++ b/src/example-archive/simple-examples/working/division.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/division.c.z3
+++ b/src/example-archive/simple-examples/working/division.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/effect_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/effect_1.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: write_g_to_1 -- pass
+[2/2]: effect_1 -- pass

--- a/src/example-archive/simple-examples/working/effect_1.c.z3
+++ b/src/example-archive/simple-examples/working/effect_1.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: write_g_to_1 -- pass
+[2/2]: effect_1 -- pass

--- a/src/example-archive/simple-examples/working/for_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/for_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: for_1 -- pass

--- a/src/example-archive/simple-examples/working/for_1.c.z3
+++ b/src/example-archive/simple-examples/working/for_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: for_1 -- pass

--- a/src/example-archive/simple-examples/working/for_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/for_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: for_2 -- pass

--- a/src/example-archive/simple-examples/working/for_2.c.z3
+++ b/src/example-archive/simple-examples/working/for_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: for_2 -- pass

--- a/src/example-archive/simple-examples/working/for_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/for_3.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: for_3 -- pass

--- a/src/example-archive/simple-examples/working/for_3.c.z3
+++ b/src/example-archive/simple-examples/working/for_3.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: for_3 -- pass

--- a/src/example-archive/simple-examples/working/free_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/free_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: free_1 -- pass

--- a/src/example-archive/simple-examples/working/free_1.c.z3
+++ b/src/example-archive/simple-examples/working/free_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: free_1 -- pass

--- a/src/example-archive/simple-examples/working/inc_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/inc_1.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: inc_1_pre -- pass
+[2/2]: inc_1_post -- pass

--- a/src/example-archive/simple-examples/working/inc_1.c.z3
+++ b/src/example-archive/simple-examples/working/inc_1.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: inc_1_pre -- pass
+[2/2]: inc_1_post -- pass

--- a/src/example-archive/simple-examples/working/int_to_char_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/int_to_char_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: int_to_char_1 -- pass

--- a/src/example-archive/simple-examples/working/int_to_char_1.c.z3
+++ b/src/example-archive/simple-examples/working/int_to_char_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: int_to_char_1 -- pass

--- a/src/example-archive/simple-examples/working/lemma_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/lemma_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: lemma_1 -- pass

--- a/src/example-archive/simple-examples/working/lemma_1.c.z3
+++ b/src/example-archive/simple-examples/working/lemma_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: lemma_1 -- pass

--- a/src/example-archive/simple-examples/working/list_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/list_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: list_1 -- pass

--- a/src/example-archive/simple-examples/working/list_1.c.z3
+++ b/src/example-archive/simple-examples/working/list_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: list_1 -- pass

--- a/src/example-archive/simple-examples/working/list_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/list_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: list_2 -- pass

--- a/src/example-archive/simple-examples/working/list_2.c.z3
+++ b/src/example-archive/simple-examples/working/list_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: list_2 -- pass

--- a/src/example-archive/simple-examples/working/list_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/list_3.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/simple-examples/working/list_3.c:15:32: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+    assert (is_null(H.next) || H.next != NULL);
+                               ~~~~~~~^~~~~~~ 
+[1/1]: list_3 -- pass

--- a/src/example-archive/simple-examples/working/list_3.c.z3
+++ b/src/example-archive/simple-examples/working/list_3.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/simple-examples/working/list_3.c:15:32: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+    assert (is_null(H.next) || H.next != NULL);
+                               ~~~~~~~^~~~~~~ 
+[1/1]: list_3 -- pass

--- a/src/example-archive/simple-examples/working/list_4.c.cvc5
+++ b/src/example-archive/simple-examples/working/list_4.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: list_reverse_1 -- pass

--- a/src/example-archive/simple-examples/working/list_4.c.z3
+++ b/src/example-archive/simple-examples/working/list_4.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: list_reverse_1 -- pass

--- a/src/example-archive/simple-examples/working/long_type.c.cvc5
+++ b/src/example-archive/simple-examples/working/long_type.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: long_type_err_1 -- pass

--- a/src/example-archive/simple-examples/working/long_type.c.z3
+++ b/src/example-archive/simple-examples/working/long_type.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: long_type_err_1 -- pass

--- a/src/example-archive/simple-examples/working/loop_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_1 -- pass

--- a/src/example-archive/simple-examples/working/loop_1.c.z3
+++ b/src/example-archive/simple-examples/working/loop_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_1 -- pass

--- a/src/example-archive/simple-examples/working/loop_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_2 -- pass

--- a/src/example-archive/simple-examples/working/loop_2.c.z3
+++ b/src/example-archive/simple-examples/working/loop_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_2 -- pass

--- a/src/example-archive/simple-examples/working/loop_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_3.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_3 -- pass

--- a/src/example-archive/simple-examples/working/loop_3.c.z3
+++ b/src/example-archive/simple-examples/working/loop_3.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_3 -- pass

--- a/src/example-archive/simple-examples/working/loop_4.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_4.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_4 -- pass

--- a/src/example-archive/simple-examples/working/loop_4.c.z3
+++ b/src/example-archive/simple-examples/working/loop_4.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_4 -- pass

--- a/src/example-archive/simple-examples/working/loop_5.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_5.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_5 -- pass

--- a/src/example-archive/simple-examples/working/loop_5.c.z3
+++ b/src/example-archive/simple-examples/working/loop_5.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_5 -- pass

--- a/src/example-archive/simple-examples/working/loop_6.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_6.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_6 -- pass

--- a/src/example-archive/simple-examples/working/loop_6.c.z3
+++ b/src/example-archive/simple-examples/working/loop_6.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_6 -- pass

--- a/src/example-archive/simple-examples/working/loop_7.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_7.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_7 -- pass

--- a/src/example-archive/simple-examples/working/loop_7.c.z3
+++ b/src/example-archive/simple-examples/working/loop_7.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_7 -- pass

--- a/src/example-archive/simple-examples/working/loop_8.c.cvc5
+++ b/src/example-archive/simple-examples/working/loop_8.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_8 -- pass

--- a/src/example-archive/simple-examples/working/loop_8.c.z3
+++ b/src/example-archive/simple-examples/working/loop_8.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: loop_8 -- pass

--- a/src/example-archive/simple-examples/working/malloc_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/malloc_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: malloc__1 -- pass

--- a/src/example-archive/simple-examples/working/malloc_1.c.z3
+++ b/src/example-archive/simple-examples/working/malloc_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: malloc__1 -- pass

--- a/src/example-archive/simple-examples/working/neg_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/neg_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: neg_1 -- pass

--- a/src/example-archive/simple-examples/working/neg_1.c.z3
+++ b/src/example-archive/simple-examples/working/neg_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: neg_1 -- pass

--- a/src/example-archive/simple-examples/working/pointer_dec1.c.cvc5
+++ b/src/example-archive/simple-examples/working/pointer_dec1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: b -- pass

--- a/src/example-archive/simple-examples/working/pointer_dec1.c.z3
+++ b/src/example-archive/simple-examples/working/pointer_dec1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: b -- pass

--- a/src/example-archive/simple-examples/working/pointer_dec2.c.cvc5
+++ b/src/example-archive/simple-examples/working/pointer_dec2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: b -- pass

--- a/src/example-archive/simple-examples/working/pointer_dec2.c.z3
+++ b/src/example-archive/simple-examples/working/pointer_dec2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: b -- pass

--- a/src/example-archive/simple-examples/working/power_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/power_1.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: power_1 -- pass
+[2/2]: power_1_alt -- pass

--- a/src/example-archive/simple-examples/working/power_1.c.z3
+++ b/src/example-archive/simple-examples/working/power_1.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: power_1 -- pass
+[2/2]: power_1_alt -- pass

--- a/src/example-archive/simple-examples/working/power_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/power_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: power_2 -- pass

--- a/src/example-archive/simple-examples/working/power_2.c.z3
+++ b/src/example-archive/simple-examples/working/power_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: power_2 -- pass

--- a/src/example-archive/simple-examples/working/pred_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/pred_2.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: pred_2_var1 -- pass
+[2/3]: pred_2_var2 -- pass
+[3/3]: pred_2_var3 -- pass

--- a/src/example-archive/simple-examples/working/pred_2.c.z3
+++ b/src/example-archive/simple-examples/working/pred_2.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: pred_2_var1 -- pass
+[2/3]: pred_2_var2 -- pass
+[3/3]: pred_2_var3 -- pass

--- a/src/example-archive/simple-examples/working/ret_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/ret_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ret_1 -- pass

--- a/src/example-archive/simple-examples/working/ret_1.c.z3
+++ b/src/example-archive/simple-examples/working/ret_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ret_1 -- pass

--- a/src/example-archive/simple-examples/working/string_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/string_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/string_1.c.z3
+++ b/src/example-archive/simple-examples/working/string_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/struct_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/struct_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: struct_1 -- pass

--- a/src/example-archive/simple-examples/working/struct_1.c.z3
+++ b/src/example-archive/simple-examples/working/struct_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: struct_1 -- pass

--- a/src/example-archive/simple-examples/working/struct_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/struct_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: struct_2 -- pass

--- a/src/example-archive/simple-examples/working/struct_2.c.z3
+++ b/src/example-archive/simple-examples/working/struct_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: struct_2 -- pass

--- a/src/example-archive/simple-examples/working/struct_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/struct_3.c.cvc5
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/example-archive/simple-examples/working/struct_3.c.z3
+++ b/src/example-archive/simple-examples/working/struct_3.c.z3
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/example-archive/simple-examples/working/swap_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/swap_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: swap_1 -- pass

--- a/src/example-archive/simple-examples/working/swap_1.c.z3
+++ b/src/example-archive/simple-examples/working/swap_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: swap_1 -- pass

--- a/src/example-archive/simple-examples/working/switch_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/switch_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/switch_1.c.z3
+++ b/src/example-archive/simple-examples/working/switch_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/voidfn_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/voidfn_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/voidfn_1.c.z3
+++ b/src/example-archive/simple-examples/working/voidfn_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: a -- pass

--- a/src/example-archive/simple-examples/working/write_1.c.cvc5
+++ b/src/example-archive/simple-examples/working/write_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: write_1 -- pass

--- a/src/example-archive/simple-examples/working/write_1.c.z3
+++ b/src/example-archive/simple-examples/working/write_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: write_1 -- pass

--- a/src/example-archive/simple-examples/working/write_2.c.cvc5
+++ b/src/example-archive/simple-examples/working/write_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: write_2 -- pass

--- a/src/example-archive/simple-examples/working/write_2.c.z3
+++ b/src/example-archive/simple-examples/working/write_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: write_2 -- pass

--- a/src/example-archive/simple-examples/working/write_3.c.cvc5
+++ b/src/example-archive/simple-examples/working/write_3.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/simple-examples/working/write_3.c:6:7: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+      cell1 == cell2; @*/
+      ~~~~~~^~~~~~~~ 
+[1/1]: write_3 -- pass

--- a/src/example-archive/simple-examples/working/write_3.c.z3
+++ b/src/example-archive/simple-examples/working/write_3.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+./src/example-archive/simple-examples/working/write_3.c:6:7: warning: CN pointer equality is not the same as C's (will not warn again). Please use `ptr_eq` or `is_null` (maybe `addr_eq`).
+      cell1 == cell2; @*/
+      ~~~~~~^~~~~~~~ 
+[1/1]: write_3 -- pass

--- a/src/example-archive/simple-examples/working/write_4.c.cvc5
+++ b/src/example-archive/simple-examples/working/write_4.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: write_4 -- pass

--- a/src/example-archive/simple-examples/working/write_4.c.z3
+++ b/src/example-archive/simple-examples/working/write_4.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: write_4 -- pass

--- a/src/example-archive/simple-examples/working/write_5.c.cvc5
+++ b/src/example-archive/simple-examples/working/write_5.c.cvc5
@@ -1,0 +1,15 @@
+return code: 0
+./src/example-archive/simple-examples/working/write_5.c:21:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take PairPre = each (i32 j; j == 0i32 || j == 1i32) {Owned(pair + j)}; @*/
+           ^
+./src/example-archive/simple-examples/working/write_5.c:23:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take PairPost = each (i32 j; j == 0i32 || j == 1i32) {Owned(pair + j)}; 
+           ^
+./src/example-archive/simple-examples/working/write_5.c:28:27: warning: 'extract' expects a 'u64', but '0'i32' with type 'i32' was provided. This will become an error in the future.
+  /*@ extract Owned<int>, 0i32; @*/
+                          ^
+./src/example-archive/simple-examples/working/write_5.c:30:27: warning: 'extract' expects a 'u64', but '1'i32' with type 'i32' was provided. This will become an error in the future.
+  /*@ extract Owned<int>, 1i32; @*/
+                          ^
+[1/2]: write_5 -- pass
+[2/2]: write_5_alt -- pass

--- a/src/example-archive/simple-examples/working/write_5.c.z3
+++ b/src/example-archive/simple-examples/working/write_5.c.z3
@@ -1,0 +1,15 @@
+return code: 0
+./src/example-archive/simple-examples/working/write_5.c:21:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take PairPre = each (i32 j; j == 0i32 || j == 1i32) {Owned(pair + j)}; @*/
+           ^
+./src/example-archive/simple-examples/working/write_5.c:23:12: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+      take PairPost = each (i32 j; j == 0i32 || j == 1i32) {Owned(pair + j)}; 
+           ^
+./src/example-archive/simple-examples/working/write_5.c:28:27: warning: 'extract' expects a 'u64', but '0'i32' with type 'i32' was provided. This will become an error in the future.
+  /*@ extract Owned<int>, 0i32; @*/
+                          ^
+./src/example-archive/simple-examples/working/write_5.c:30:27: warning: 'extract' expects a 'u64', but '1'i32' with type 'i32' was provided. This will become an error in the future.
+  /*@ extract Owned<int>, 1i32; @*/
+                          ^
+[1/2]: write_5 -- pass
+[2/2]: write_5_alt -- pass

--- a/src/examples/abs.c.cvc5
+++ b/src/examples/abs.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs -- pass

--- a/src/examples/abs.c.z3
+++ b/src/examples/abs.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs -- pass

--- a/src/examples/abs_mem.c.cvc5
+++ b/src/examples/abs_mem.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs_mem -- pass

--- a/src/examples/abs_mem.c.z3
+++ b/src/examples/abs_mem.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: abs_mem -- pass

--- a/src/examples/abs_mem_struct.c.cvc5
+++ b/src/examples/abs_mem_struct.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: abs_mem -- pass
+[2/2]: abs_y -- pass

--- a/src/examples/abs_mem_struct.c.z3
+++ b/src/examples/abs_mem_struct.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: abs_mem -- pass
+[2/2]: abs_y -- pass

--- a/src/examples/add_0.c.cvc5
+++ b/src/examples/add_0.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_0.c.z3
+++ b/src/examples/add_0.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_1.c.cvc5
+++ b/src/examples/add_1.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_1.c.z3
+++ b/src/examples/add_1.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_2.c.cvc5
+++ b/src/examples/add_2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_2.c.z3
+++ b/src/examples/add_2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_read.c.cvc5
+++ b/src/examples/add_read.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_read.c.z3
+++ b/src/examples/add_read.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: add -- pass

--- a/src/examples/add_two_array.c.cvc5
+++ b/src/examples/add_two_array.c.cvc5
@@ -1,0 +1,12 @@
+return code: 0
+./src/examples/add_two_array.c:3:19: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take A = each(i32 k; 0i32 <= k && k < n) { 
+                  ^
+./src/examples/add_two_array.c:8:18: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+    ensures take A_post = each(i32 k; 0i32 <= k && k < n) { 
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_read_two -- pass

--- a/src/examples/add_two_array.c.z3
+++ b/src/examples/add_two_array.c.z3
@@ -1,0 +1,12 @@
+return code: 0
+./src/examples/add_two_array.c:3:19: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take A = each(i32 k; 0i32 <= k && k < n) { 
+                  ^
+./src/examples/add_two_array.c:8:18: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+    ensures take A_post = each(i32 k; 0i32 <= k && k < n) { 
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: array_read_two -- pass

--- a/src/examples/array_load.broken.c.cvc5
+++ b/src/examples/array_load.broken.c.cvc5
@@ -1,0 +1,13 @@
+return code: 1
+./src/examples/array_load.broken.c:2:19: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take A = each(i32 j; 0i32 <= j && j < n) { 
+                  ^
+./src/examples/array_load.broken.c:5:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+    ensures take A_post = each(i32 j; 0i32 <= j && j < n) { 
+                 ^
+[1/1]: read -- fail
+./src/examples/array_load.broken.c:9:10: error: `&p[(u64)i]` out of bounds
+  return p[i];
+         ^~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__array_load.broken.c__read.html

--- a/src/examples/array_load.broken.c.z3
+++ b/src/examples/array_load.broken.c.z3
@@ -1,0 +1,13 @@
+return code: 1
+./src/examples/array_load.broken.c:2:19: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take A = each(i32 j; 0i32 <= j && j < n) { 
+                  ^
+./src/examples/array_load.broken.c:5:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+    ensures take A_post = each(i32 j; 0i32 <= j && j < n) { 
+                 ^
+[1/1]: read -- fail
+./src/examples/array_load.broken.c:9:10: error: `&p[(u64)i]` out of bounds
+  return p[i];
+         ^~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__array_load.broken.c__read.html

--- a/src/examples/array_load.c.cvc5
+++ b/src/examples/array_load.c.cvc5
@@ -1,0 +1,10 @@
+return code: 0
+./src/examples/array_load.c:2:19: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take A = each(i32 j; 0i32 <= j && j < n) { 
+                  ^
+./src/examples/array_load.c:5:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+    ensures take A_post = each(i32 j; 0i32 <= j && j < n) { 
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: read -- pass

--- a/src/examples/array_load.c.z3
+++ b/src/examples/array_load.c.z3
@@ -1,0 +1,10 @@
+return code: 0
+./src/examples/array_load.c:2:19: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take A = each(i32 j; 0i32 <= j && j < n) { 
+                  ^
+./src/examples/array_load.c:5:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+    ensures take A_post = each(i32 j; 0i32 <= j && j < n) { 
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: read -- pass

--- a/src/examples/array_load2.c.cvc5
+++ b/src/examples/array_load2.c.cvc5
@@ -1,0 +1,10 @@
+return code: 0
+./src/examples/array_load2.c:2:19: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take a1 = each(i32 j; 0i32 <= j && j < n) { Owned<int>(array_shift<int>(p,j)) };
+                  ^
+./src/examples/array_load2.c:4:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+    ensures take a2 = each(i32 j; 0i32 <= j && j < n) { Owned<int>(array_shift<int>(p,j)) };
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: read -- pass

--- a/src/examples/array_load2.c.z3
+++ b/src/examples/array_load2.c.z3
@@ -1,0 +1,10 @@
+return code: 0
+./src/examples/array_load2.c:2:19: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take a1 = each(i32 j; 0i32 <= j && j < n) { Owned<int>(array_shift<int>(p,j)) };
+                  ^
+./src/examples/array_load2.c:4:18: warning: 'each' expects a 'u64', but 'j' with type 'i32' was provided. This will become an error in the future.
+    ensures take a2 = each(i32 j; 0i32 <= j && j < n) { Owned<int>(array_shift<int>(p,j)) };
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: read -- pass

--- a/src/examples/bcp_framerule.c.cvc5
+++ b/src/examples/bcp_framerule.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr_first -- pass
+[2/2]: incr_first_frame -- pass

--- a/src/examples/bcp_framerule.c.z3
+++ b/src/examples/bcp_framerule.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr_first -- pass
+[2/2]: incr_first_frame -- pass

--- a/src/examples/const_example.c.cvc5
+++ b/src/examples/const_example.c.cvc5
@@ -1,0 +1,6 @@
+return code: 0
+./src/examples/const_example.c:3:30: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+    static int c_CONST() /*@ cn_function CONST; @*/ { return CONST; }
+                             ^~~~~~~~~~~ 
+[1/2]: c_CONST -- pass
+[2/2]: foo -- pass

--- a/src/examples/const_example.c.z3
+++ b/src/examples/const_example.c.z3
@@ -1,0 +1,6 @@
+return code: 0
+./src/examples/const_example.c:3:30: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+    static int c_CONST() /*@ cn_function CONST; @*/ { return CONST; }
+                             ^~~~~~~~~~~ 
+[1/2]: c_CONST -- pass
+[2/2]: foo -- pass

--- a/src/examples/const_example_lessgood.c.cvc5
+++ b/src/examples/const_example_lessgood.c.cvc5
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/examples/const_example_lessgood.c.z3
+++ b/src/examples/const_example_lessgood.c.z3
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/examples/dll/add.c.cvc5
+++ b/src/examples/dll/add.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/examples/dll/add.c.z3
+++ b/src/examples/dll/add.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: add -- pass

--- a/src/examples/dll/add_orig.broken.c.cvc5
+++ b/src/examples/dll/add_orig.broken.c.cvc5
@@ -1,0 +1,8 @@
+return code: 1
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: add -- fail
+./src/examples/dll/add_orig.broken.c:15:9: error: Left-over unused resource 'Owned<struct dllist*>(&call_malloc__dllist0.return->next)(NULL)'
+        return new_dllist;
+        ^~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__add_orig.broken.c__add.html

--- a/src/examples/dll/add_orig.broken.c.z3
+++ b/src/examples/dll/add_orig.broken.c.z3
@@ -1,0 +1,8 @@
+return code: 1
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: add -- fail
+./src/examples/dll/add_orig.broken.c:15:9: error: Left-over unused resource 'Owned<struct dllist*>(&call_malloc__dllist0.return->next)(NULL)'
+        return new_dllist;
+        ^~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__add_orig.broken.c__add.html

--- a/src/examples/dll/remove.c.cvc5
+++ b/src/examples/dll/remove.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/examples/dll/remove.c.z3
+++ b/src/examples/dll/remove.c.z3
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/examples/dll/remove_orig.broken.c.cvc5
+++ b/src/examples/dll/remove_orig.broken.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: remove -- fail
+./src/examples/dll/remove_orig.broken.c:9:9: error: Pointer `n` needs allocation ID
+    if (n->prev != 0) {
+        ~^~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__remove_orig.broken.c__remove.html

--- a/src/examples/dll/remove_orig.broken.c.z3
+++ b/src/examples/dll/remove_orig.broken.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: remove -- fail
+./src/examples/dll/remove_orig.broken.c:9:9: error: Pointer `n` needs allocation ID
+    if (n->prev != 0) {
+        ~^~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__remove_orig.broken.c__remove.html

--- a/src/examples/dll/singleton.c.cvc5
+++ b/src/examples/dll/singleton.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: singleton -- pass

--- a/src/examples/dll/singleton.c.z3
+++ b/src/examples/dll/singleton.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: singleton -- pass

--- a/src/examples/init_array.c.cvc5
+++ b/src/examples/init_array.c.cvc5
@@ -1,0 +1,16 @@
+return code: 0
+./src/examples/init_array.c:2:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+/*@ requires take A = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array.c:4:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+    ensures  take A_post = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Ai = each(u32 i; i < n) { 
+               ^
+./src/examples/init_array.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Ai = each(u32 i; i < n) { 
+               ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'u32' was provided. This will become an error in the future.
+
+[1/1]: init_array -- pass

--- a/src/examples/init_array.c.z3
+++ b/src/examples/init_array.c.z3
@@ -1,0 +1,16 @@
+return code: 0
+./src/examples/init_array.c:2:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+/*@ requires take A = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array.c:4:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+    ensures  take A_post = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Ai = each(u32 i; i < n) { 
+               ^
+./src/examples/init_array.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Ai = each(u32 i; i < n) { 
+               ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'u32' was provided. This will become an error in the future.
+
+[1/1]: init_array -- pass

--- a/src/examples/init_array2.c.cvc5
+++ b/src/examples/init_array2.c.cvc5
@@ -1,0 +1,27 @@
+return code: 0
+./src/examples/init_array2.c:2:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+/*@ requires take A = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array2.c:4:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+    ensures  take A_post = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array2.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < j) { 
+               ^
+./src/examples/init_array2.c:13:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; j <= i && i < n) { 
+               ^
+./src/examples/init_array2.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < j) { 
+               ^
+./src/examples/init_array2.c:13:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; j <= i && i < n) { 
+               ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'u32' was provided. This will become an error in the future.
+
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j1' with type 'u32' was provided. This will become an error in the future.
+
+./src/examples/init_array2.c:22:9: warning: extract: index added, no resources (yet) extracted.
+    /*@ extract Owned<char>, j; @*/
+        ^~~~~~~~~~~~~~~~~~~~~~~ 
+[1/1]: init_array2 -- pass

--- a/src/examples/init_array2.c.z3
+++ b/src/examples/init_array2.c.z3
@@ -1,0 +1,27 @@
+return code: 0
+./src/examples/init_array2.c:2:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+/*@ requires take A = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array2.c:4:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+    ensures  take A_post = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array2.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < j) { 
+               ^
+./src/examples/init_array2.c:13:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; j <= i && i < n) { 
+               ^
+./src/examples/init_array2.c:11:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < j) { 
+               ^
+./src/examples/init_array2.c:13:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; j <= i && i < n) { 
+               ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'u32' was provided. This will become an error in the future.
+
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j1' with type 'u32' was provided. This will become an error in the future.
+
+./src/examples/init_array2.c:22:9: warning: extract: index added, no resources (yet) extracted.
+    /*@ extract Owned<char>, j; @*/
+        ^~~~~~~~~~~~~~~~~~~~~~~ 
+[1/1]: init_array2 -- pass

--- a/src/examples/init_array_rev.c.cvc5
+++ b/src/examples/init_array_rev.c.cvc5
@@ -1,0 +1,31 @@
+return code: 0
+./src/examples/init_array_rev.c:2:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+/*@ requires take A = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array_rev.c:5:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+    ensures  take A_post = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array_rev.c:12:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < n-j) { 
+               ^
+./src/examples/init_array_rev.c:14:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; n-j <= i && i < n) { 
+               ^
+./src/examples/init_array_rev.c:12:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < n-j) { 
+               ^
+./src/examples/init_array_rev.c:14:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; n-j <= i && i < n) { 
+               ^
+./src/examples/init_array_rev.c:22:30: warning: 'extract' expects a 'u64', but 'read_&n0
+- (read_&j0 + 1'u32)' with type 'u32' was provided. This will become an error in the future.
+    /*@ extract Block<char>, n-(j+1u32); @*/
+                             ~^~~~~~~~~ 
+./src/examples/init_array_rev.c:23:30: warning: 'extract' expects a 'u64', but 'read_&n1
+- (read_&j1 + 1'u32)' with type 'u32' was provided. This will become an error in the future.
+    /*@ extract Owned<char>, n-(j+1u32); @*/
+                             ~^~~~~~~~~ 
+./src/examples/init_array_rev.c:23:9: warning: extract: index added, no resources (yet) extracted.
+    /*@ extract Owned<char>, n-(j+1u32); @*/
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+[1/1]: init_array_rev -- pass

--- a/src/examples/init_array_rev.c.z3
+++ b/src/examples/init_array_rev.c.z3
@@ -1,0 +1,31 @@
+return code: 0
+./src/examples/init_array_rev.c:2:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+/*@ requires take A = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array_rev.c:5:19: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+    ensures  take A_post = each(u32 i; i < n) { 
+                  ^
+./src/examples/init_array_rev.c:12:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < n-j) { 
+               ^
+./src/examples/init_array_rev.c:14:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; n-j <= i && i < n) { 
+               ^
+./src/examples/init_array_rev.c:12:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+  /*@ inv take Al = each(u32 i; i < n-j) { 
+               ^
+./src/examples/init_array_rev.c:14:16: warning: 'each' expects a 'u64', but 'i' with type 'u32' was provided. This will become an error in the future.
+          take Ar = each(u32 i; n-j <= i && i < n) { 
+               ^
+./src/examples/init_array_rev.c:22:30: warning: 'extract' expects a 'u64', but 'read_&n0
+- (read_&j0 + 1'u32)' with type 'u32' was provided. This will become an error in the future.
+    /*@ extract Block<char>, n-(j+1u32); @*/
+                             ~^~~~~~~~~ 
+./src/examples/init_array_rev.c:23:30: warning: 'extract' expects a 'u64', but 'read_&n1
+- (read_&j1 + 1'u32)' with type 'u32' was provided. This will become an error in the future.
+    /*@ extract Owned<char>, n-(j+1u32); @*/
+                             ~^~~~~~~~~ 
+./src/examples/init_array_rev.c:23:9: warning: extract: index added, no resources (yet) extracted.
+    /*@ extract Owned<char>, n-(j+1u32); @*/
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+[1/1]: init_array_rev -- pass

--- a/src/examples/init_point.c.cvc5
+++ b/src/examples/init_point.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: zero -- pass
+[2/2]: init_point -- pass

--- a/src/examples/init_point.c.z3
+++ b/src/examples/init_point.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: zero -- pass
+[2/2]: init_point -- pass

--- a/src/examples/list/append.c.cvc5
+++ b/src/examples/list/append.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: IntList_append -- pass

--- a/src/examples/list/append.c.z3
+++ b/src/examples/list/append.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: IntList_append -- pass

--- a/src/examples/list/append2.c.cvc5
+++ b/src/examples/list/append2.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: slnil -- pass
+[2/4]: slcons -- pass
+[3/4]: IntList_copy -- pass
+[4/4]: IntList_append2 -- pass

--- a/src/examples/list/append2.c.z3
+++ b/src/examples/list/append2.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: slnil -- pass
+[2/4]: slcons -- pass
+[3/4]: IntList_copy -- pass
+[4/4]: IntList_append2 -- pass

--- a/src/examples/list/copy.c.cvc5
+++ b/src/examples/list/copy.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: slcopy -- pass

--- a/src/examples/list/copy.c.z3
+++ b/src/examples/list/copy.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: slcopy -- pass

--- a/src/examples/list/free.c.cvc5
+++ b/src/examples/list/free.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: free__rec_sllist -- pass

--- a/src/examples/list/free.c.z3
+++ b/src/examples/list/free.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: free__rec_sllist -- pass

--- a/src/examples/list/length.c.cvc5
+++ b/src/examples/list/length.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: length -- pass

--- a/src/examples/list/length.c.z3
+++ b/src/examples/list/length.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: length -- pass

--- a/src/examples/list/mergesort.c.cvc5
+++ b/src/examples/list/mergesort.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/examples/list/mergesort.c.z3
+++ b/src/examples/list/mergesort.c.z3
@@ -1,0 +1,6 @@
+return code: 0
+[1/5]: slnil -- pass
+[2/5]: slcons -- pass
+[3/5]: split -- pass
+[4/5]: merge -- pass
+[5/5]: mergesort -- pass

--- a/src/examples/list/rev.c.cvc5
+++ b/src/examples/list/rev.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: slnil -- pass
+[2/4]: slcons -- pass
+[3/4]: rev_aux -- pass
+[4/4]: rev -- pass

--- a/src/examples/list/rev.c.z3
+++ b/src/examples/list/rev.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: slnil -- pass
+[2/4]: slcons -- pass
+[3/4]: rev_aux -- pass
+[4/4]: rev -- pass

--- a/src/examples/list/rev_alt.c.cvc5
+++ b/src/examples/list/rev_alt.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: rev_loop -- pass

--- a/src/examples/list/rev_alt.c.z3
+++ b/src/examples/list/rev_alt.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: slnil -- pass
+[2/3]: slcons -- pass
+[3/3]: rev_loop -- pass

--- a/src/examples/queue/empty.c.cvc5
+++ b/src/examples/queue/empty.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: empty_queue -- pass

--- a/src/examples/queue/empty.c.z3
+++ b/src/examples/queue/empty.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: empty_queue -- pass

--- a/src/examples/queue/pop.c.cvc5
+++ b/src/examples/queue/pop.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: pop_queue -- pass

--- a/src/examples/queue/pop.c.z3
+++ b/src/examples/queue/pop.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: pop_queue -- pass

--- a/src/examples/queue/pop_orig.broken.c.cvc5
+++ b/src/examples/queue/pop_orig.broken.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: pop_queue -- fail
+./src/examples/queue/pop_orig.broken.c:5:26: error: Pointer `q` needs allocation ID
+  struct queue_cell* h = q->front;
+                         ~^~~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__pop_orig.broken.c__pop_queue.html

--- a/src/examples/queue/pop_orig.broken.c.z3
+++ b/src/examples/queue/pop_orig.broken.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: pop_queue -- fail
+./src/examples/queue/pop_orig.broken.c:5:26: error: Pointer `q` needs allocation ID
+  struct queue_cell* h = q->front;
+                         ~^~~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__pop_orig.broken.c__pop_queue.html

--- a/src/examples/queue/pop_unified.c.cvc5
+++ b/src/examples/queue/pop_unified.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: snoc_fact -- pass
+[2/3]: snoc_fact_unified -- pass
+[3/3]: pop_queue -- pass

--- a/src/examples/queue/pop_unified.c.z3
+++ b/src/examples/queue/pop_unified.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: snoc_fact -- pass
+[2/3]: snoc_fact_unified -- pass
+[3/3]: pop_queue -- pass

--- a/src/examples/queue/push.c.cvc5
+++ b/src/examples/queue/push.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: push_queue -- pass

--- a/src/examples/queue/push.c.z3
+++ b/src/examples/queue/push.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: push_queue -- pass

--- a/src/examples/queue/push_induction.c.cvc5
+++ b/src/examples/queue/push_induction.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/examples/queue/push_induction.c.z3
+++ b/src/examples/queue/push_induction.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: push_induction -- pass
+[2/2]: push_queue -- pass

--- a/src/examples/queue/push_orig.broken.c.cvc5
+++ b/src/examples/queue/push_orig.broken.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: push_queue -- fail
+./src/examples/queue/push_orig.broken.c:8:7: error: Pointer `q` needs allocation ID
+  if (q->back == 0) {
+      ~^~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__push_orig.broken.c__push_queue.html

--- a/src/examples/queue/push_orig.broken.c.z3
+++ b/src/examples/queue/push_orig.broken.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: push_queue -- fail
+./src/examples/queue/push_orig.broken.c:8:7: error: Pointer `q` needs allocation ID
+  if (q->back == 0) {
+      ~^~~~~~ 
+(UB missing short message): UB_CERB004_unspecified__pointer_add
+State file: file:///tmp/state__push_orig.broken.c__push_queue.html

--- a/src/examples/read.broken.c.cvc5
+++ b/src/examples/read.broken.c.cvc5
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: read -- fail
+./src/examples/read.broken.c:4:3: error: Left-over unused resource 'Owned<signed int>(p)(v1)'
+  return *p;
+  ^~~~~~~~~~ 
+State file: file:///tmp/state__read.broken.c__read.html

--- a/src/examples/read.broken.c.z3
+++ b/src/examples/read.broken.c.z3
@@ -1,0 +1,6 @@
+return code: 1
+[1/1]: read -- fail
+./src/examples/read.broken.c:4:3: error: Left-over unused resource 'Owned<signed int>(p)(v1)'
+  return *p;
+  ^~~~~~~~~~ 
+State file: file:///tmp/state__read.broken.c__read.html

--- a/src/examples/read.c.cvc5
+++ b/src/examples/read.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: read -- pass

--- a/src/examples/read.c.z3
+++ b/src/examples/read.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: read -- pass

--- a/src/examples/read2.c.cvc5
+++ b/src/examples/read2.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: read -- pass

--- a/src/examples/read2.c.z3
+++ b/src/examples/read2.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: read -- pass

--- a/src/examples/runway/funcs2.c.cvc5
+++ b/src/examples/runway/funcs2.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/examples/runway/funcs2.c.z3
+++ b/src/examples/runway/funcs2.c.z3
@@ -1,0 +1,15 @@
+return code: 0
+./src/examples/runway/state.h:3:33: warning: experimental keyword 'cn_function' (use of experimental features is discouraged)
+    static int c_INACTIVE() /*@ cn_function INACTIVE; @*/ { return INACTIVE; }
+                                ^~~~~~~~~~~ 
+[1/11]: c_INACTIVE -- pass
+[2/11]: c_ACTIVE -- pass
+[3/11]: init -- pass
+[4/11]: increment_Plane_Counter -- pass
+[5/11]: reset_Plane_Counter -- pass
+[6/11]: increment_Runway_Time -- pass
+[7/11]: reset_Runway_Time -- pass
+[8/11]: arrive -- pass
+[9/11]: depart -- pass
+[10/11]: switch_modes -- pass
+[11/11]: tick -- pass

--- a/src/examples/slf0_basic_incr.c.cvc5
+++ b/src/examples/slf0_basic_incr.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: incr -- pass

--- a/src/examples/slf0_basic_incr.c.z3
+++ b/src/examples/slf0_basic_incr.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: incr -- pass

--- a/src/examples/slf0_basic_incr.signed.broken.c.cvc5
+++ b/src/examples/slf0_basic_incr.signed.broken.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: incr -- fail
+./src/examples/slf0_basic_incr.signed.broken.c:6:8: error: Missing resource for reading
+  *p = *p+1;
+       ^~ 
+Resource needed: Owned<signed int>(p)
+State file: file:///tmp/state__slf0_basic_incr.signed.broken.c__incr.html

--- a/src/examples/slf0_basic_incr.signed.broken.c.z3
+++ b/src/examples/slf0_basic_incr.signed.broken.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: incr -- fail
+./src/examples/slf0_basic_incr.signed.broken.c:6:8: error: Missing resource for reading
+  *p = *p+1;
+       ^~ 
+Resource needed: Owned<signed int>(p)
+State file: file:///tmp/state__slf0_basic_incr.signed.broken.c__incr.html

--- a/src/examples/slf0_basic_incr.signed.c.cvc5
+++ b/src/examples/slf0_basic_incr.signed.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: incr -- pass

--- a/src/examples/slf0_basic_incr.signed.c.z3
+++ b/src/examples/slf0_basic_incr.signed.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: incr -- pass

--- a/src/examples/slf0_incr.broken.c.cvc5
+++ b/src/examples/slf0_incr.broken.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: incr -- fail
+./src/examples/slf0_incr.broken.c:8:11: error: Missing resource for reading
+  int n = *p;
+          ^~ 
+Resource needed: Owned<signed int>(p)
+State file: file:///tmp/state__slf0_incr.broken.c__incr.html

--- a/src/examples/slf0_incr.broken.c.z3
+++ b/src/examples/slf0_incr.broken.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/1]: incr -- fail
+./src/examples/slf0_incr.broken.c:8:11: error: Missing resource for reading
+  int n = *p;
+          ^~ 
+Resource needed: Owned<signed int>(p)
+State file: file:///tmp/state__slf0_incr.broken.c__incr.html

--- a/src/examples/slf10_basic_ref.c.cvc5
+++ b/src/examples/slf10_basic_ref.c.cvc5
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/examples/slf10_basic_ref.c.z3
+++ b/src/examples/slf10_basic_ref.c.z3
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/examples/slf11_basic_ref_greater.c.cvc5
+++ b/src/examples/slf11_basic_ref_greater.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ref_greater -- pass

--- a/src/examples/slf11_basic_ref_greater.c.z3
+++ b/src/examples/slf11_basic_ref_greater.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ref_greater -- pass

--- a/src/examples/slf12_basic_ref_greater_abstract.c.cvc5
+++ b/src/examples/slf12_basic_ref_greater_abstract.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ref_greater -- pass

--- a/src/examples/slf12_basic_ref_greater_abstract.c.z3
+++ b/src/examples/slf12_basic_ref_greater_abstract.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ref_greater -- pass

--- a/src/examples/slf13_basic_ref_with_frame.c.cvc5
+++ b/src/examples/slf13_basic_ref_with_frame.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: triple_ref_with_frame -- pass

--- a/src/examples/slf13_basic_ref_with_frame.c.z3
+++ b/src/examples/slf13_basic_ref_with_frame.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: triple_ref_with_frame -- pass

--- a/src/examples/slf14_basic_succ_using_incr_attempt.broken.c.cvc5
+++ b/src/examples/slf14_basic_succ_using_incr_attempt.broken.c.cvc5
@@ -1,0 +1,7 @@
+return code: 1
+[1/2]: incr -- pass
+[2/2]: succ_using_incr_attempt -- fail
+./src/examples/slf14_basic_succ_using_incr_attempt.broken.c:12:3: error: Left-over unused resource 'Owned<unsigned int>(call_refUnsignedInt0.return)(call_incr0.n2)'
+  return *p;
+  ^~~~~~~~~~ 
+State file: file:///tmp/state__slf14_basic_succ_using_incr_attempt.broken.c__succ_using_incr_attempt.html

--- a/src/examples/slf14_basic_succ_using_incr_attempt.broken.c.z3
+++ b/src/examples/slf14_basic_succ_using_incr_attempt.broken.c.z3
@@ -1,0 +1,7 @@
+return code: 1
+[1/2]: incr -- pass
+[2/2]: succ_using_incr_attempt -- fail
+./src/examples/slf14_basic_succ_using_incr_attempt.broken.c:12:3: error: Left-over unused resource 'Owned<unsigned int>(call_refUnsignedInt0.return)(call_incr0.n2)'
+  return *p;
+  ^~~~~~~~~~ 
+State file: file:///tmp/state__slf14_basic_succ_using_incr_attempt.broken.c__succ_using_incr_attempt.html

--- a/src/examples/slf15_basic_succ_using_incr_attempt_.c.cvc5
+++ b/src/examples/slf15_basic_succ_using_incr_attempt_.c.cvc5
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/examples/slf15_basic_succ_using_incr_attempt_.c.z3
+++ b/src/examples/slf15_basic_succ_using_incr_attempt_.c.z3
@@ -1,0 +1,1 @@
+return code: 0

--- a/src/examples/slf16_basic_succ_using_incr.c.cvc5
+++ b/src/examples/slf16_basic_succ_using_incr.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr -- pass
+[2/2]: succ_using_incr -- pass

--- a/src/examples/slf16_basic_succ_using_incr.c.z3
+++ b/src/examples/slf16_basic_succ_using_incr.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr -- pass
+[2/2]: succ_using_incr -- pass

--- a/src/examples/slf17_get_and_free.c.cvc5
+++ b/src/examples/slf17_get_and_free.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: get_and_free -- pass

--- a/src/examples/slf17_get_and_free.c.z3
+++ b/src/examples/slf17_get_and_free.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: get_and_free -- pass

--- a/src/examples/slf18_two_dice.c.cvc5
+++ b/src/examples/slf18_two_dice.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: two_dice -- pass

--- a/src/examples/slf18_two_dice.c.z3
+++ b/src/examples/slf18_two_dice.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: two_dice -- pass

--- a/src/examples/slf1_basic_example_let.c.cvc5
+++ b/src/examples/slf1_basic_example_let.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: example_let -- pass

--- a/src/examples/slf1_basic_example_let.c.z3
+++ b/src/examples/slf1_basic_example_let.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: example_let -- pass

--- a/src/examples/slf1_basic_example_let.signed.c.cvc5
+++ b/src/examples/slf1_basic_example_let.signed.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: doubled -- pass

--- a/src/examples/slf1_basic_example_let.signed.c.z3
+++ b/src/examples/slf1_basic_example_let.signed.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: doubled -- pass

--- a/src/examples/slf2_basic_quadruple.c.cvc5
+++ b/src/examples/slf2_basic_quadruple.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: quadruple -- pass

--- a/src/examples/slf2_basic_quadruple.c.z3
+++ b/src/examples/slf2_basic_quadruple.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: quadruple -- pass

--- a/src/examples/slf2_basic_quadruple.signed.c.cvc5
+++ b/src/examples/slf2_basic_quadruple.signed.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: quadruple -- pass

--- a/src/examples/slf2_basic_quadruple.signed.c.z3
+++ b/src/examples/slf2_basic_quadruple.signed.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: quadruple -- pass

--- a/src/examples/slf3_basic_inplace_double.c.cvc5
+++ b/src/examples/slf3_basic_inplace_double.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: inplace_double -- pass

--- a/src/examples/slf3_basic_inplace_double.c.z3
+++ b/src/examples/slf3_basic_inplace_double.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: inplace_double -- pass

--- a/src/examples/slf4_basic_incr_two.c.cvc5
+++ b/src/examples/slf4_basic_incr_two.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr -- pass
+[2/2]: incr_two -- pass

--- a/src/examples/slf4_basic_incr_two.c.z3
+++ b/src/examples/slf4_basic_incr_two.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr -- pass
+[2/2]: incr_two -- pass

--- a/src/examples/slf5_basic_aliased_call.broken.c.cvc5
+++ b/src/examples/slf5_basic_aliased_call.broken.c.cvc5
@@ -1,0 +1,10 @@
+return code: 1
+[1/3]: incr -- pass
+[2/3]: incr_two -- pass
+[3/3]: aliased_call -- fail
+./src/examples/slf5_basic_aliased_call.broken.c:8:3: error: Missing resource for calling function incr_two
+  incr_two(p, p);
+  ^~~~~~~~~~~~~~ 
+Resource needed: Owned<unsigned int>(p)
+      ./src/examples/slf4_basic_incr_two.c:5:19: (arg m1)
+State file: file:///tmp/state__slf5_basic_aliased_call.broken.c__aliased_call.html

--- a/src/examples/slf5_basic_aliased_call.broken.c.z3
+++ b/src/examples/slf5_basic_aliased_call.broken.c.z3
@@ -1,0 +1,10 @@
+return code: 1
+[1/3]: incr -- pass
+[2/3]: incr_two -- pass
+[3/3]: aliased_call -- fail
+./src/examples/slf5_basic_aliased_call.broken.c:8:3: error: Missing resource for calling function incr_two
+  incr_two(p, p);
+  ^~~~~~~~~~~~~~ 
+Resource needed: Owned<unsigned int>(p)
+      ./src/examples/slf4_basic_incr_two.c:5:19: (arg m1)
+State file: file:///tmp/state__slf5_basic_aliased_call.broken.c__aliased_call.html

--- a/src/examples/slf6_basic_incr_two_aliased_call.c.cvc5
+++ b/src/examples/slf6_basic_incr_two_aliased_call.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: incr -- pass
+[2/3]: incr_two -- pass
+[3/3]: aliased_call -- pass

--- a/src/examples/slf6_basic_incr_two_aliased_call.c.z3
+++ b/src/examples/slf6_basic_incr_two_aliased_call.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: incr -- pass
+[2/3]: incr_two -- pass
+[3/3]: aliased_call -- pass

--- a/src/examples/slf7_basic_incr_first.c.cvc5
+++ b/src/examples/slf7_basic_incr_first.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: incr -- pass
+[2/3]: incr_first -- pass
+[3/3]: incr_first_ -- pass

--- a/src/examples/slf7_basic_incr_first.c.z3
+++ b/src/examples/slf7_basic_incr_first.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: incr -- pass
+[2/3]: incr_first -- pass
+[3/3]: incr_first_ -- pass

--- a/src/examples/slf8_basic_transfer.c.cvc5
+++ b/src/examples/slf8_basic_transfer.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: transfer -- pass

--- a/src/examples/slf8_basic_transfer.c.z3
+++ b/src/examples/slf8_basic_transfer.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: transfer -- pass

--- a/src/examples/slf9_basic_transfer_aliased.c.cvc5
+++ b/src/examples/slf9_basic_transfer_aliased.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: transfer -- pass

--- a/src/examples/slf9_basic_transfer_aliased.c.z3
+++ b/src/examples/slf9_basic_transfer_aliased.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: transfer -- pass

--- a/src/examples/slf_incr2.c.cvc5
+++ b/src/examples/slf_incr2.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr2 -- pass
+[2/2]: call_both_better -- pass

--- a/src/examples/slf_incr2.c.z3
+++ b/src/examples/slf_incr2.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: incr2 -- pass
+[2/2]: call_both_better -- pass

--- a/src/examples/slf_incr2_alias.c.cvc5
+++ b/src/examples/slf_incr2_alias.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: incr2a -- pass
+[2/3]: incr2b -- pass
+[3/3]: call_both -- pass

--- a/src/examples/slf_incr2_alias.c.z3
+++ b/src/examples/slf_incr2_alias.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: incr2a -- pass
+[2/3]: incr2b -- pass
+[3/3]: call_both -- pass

--- a/src/examples/slf_incr2_noalias.c.cvc5
+++ b/src/examples/slf_incr2_noalias.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: incr2a -- pass

--- a/src/examples/slf_incr2_noalias.c.z3
+++ b/src/examples/slf_incr2_noalias.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: incr2a -- pass

--- a/src/examples/slf_length_acc.c.cvc5
+++ b/src/examples/slf_length_acc.c.cvc5
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: slnil -- pass
+[2/4]: slcons -- pass
+[3/4]: IntList_length_acc_aux -- pass
+[4/4]: IntList_length_acc -- pass

--- a/src/examples/slf_length_acc.c.z3
+++ b/src/examples/slf_length_acc.c.z3
@@ -1,0 +1,5 @@
+return code: 0
+[1/4]: slnil -- pass
+[2/4]: slcons -- pass
+[3/4]: IntList_length_acc_aux -- pass
+[4/4]: IntList_length_acc -- pass

--- a/src/examples/slf_quadruple_mem.c.cvc5
+++ b/src/examples/slf_quadruple_mem.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: quadruple_mem -- pass

--- a/src/examples/slf_quadruple_mem.c.z3
+++ b/src/examples/slf_quadruple_mem.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: quadruple_mem -- pass

--- a/src/examples/slf_ref_greater.c.cvc5
+++ b/src/examples/slf_ref_greater.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ref_greater_abstract -- pass

--- a/src/examples/slf_ref_greater.c.z3
+++ b/src/examples/slf_ref_greater.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: ref_greater_abstract -- pass

--- a/src/examples/slf_sized_stack.c.cvc5
+++ b/src/examples/slf_sized_stack.c.cvc5
@@ -1,0 +1,9 @@
+return code: 0
+[1/8]: slnil -- pass
+[2/8]: slcons -- pass
+[3/8]: length -- pass
+[4/8]: create -- pass
+[5/8]: sizeOf -- pass
+[6/8]: push -- pass
+[7/8]: pop -- pass
+[8/8]: top -- pass

--- a/src/examples/slf_sized_stack.c.z3
+++ b/src/examples/slf_sized_stack.c.z3
@@ -1,0 +1,9 @@
+return code: 0
+[1/8]: slnil -- pass
+[2/8]: slcons -- pass
+[3/8]: length -- pass
+[4/8]: create -- pass
+[5/8]: sizeOf -- pass
+[6/8]: push -- pass
+[7/8]: pop -- pass
+[8/8]: top -- pass

--- a/src/examples/swap.c.cvc5
+++ b/src/examples/swap.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: swap -- pass

--- a/src/examples/swap.c.z3
+++ b/src/examples/swap.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: swap -- pass

--- a/src/examples/swap_array.c.cvc5
+++ b/src/examples/swap_array.c.cvc5
@@ -1,0 +1,12 @@
+return code: 0
+./src/examples/swap_array.c:3:19: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take a1 = each(i32 k; 0i32 <= k && k < n) { Owned<int>(array_shift<int>(p,k)) };
+                  ^
+./src/examples/swap_array.c:7:18: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+    ensures take a2 = each(i32 k; 0i32 <= k && k < n) { Owned<int>(array_shift<int>(p,k)) };
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: swap_array -- pass

--- a/src/examples/swap_array.c.z3
+++ b/src/examples/swap_array.c.z3
@@ -1,0 +1,12 @@
+return code: 0
+./src/examples/swap_array.c:3:19: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+/*@ requires take a1 = each(i32 k; 0i32 <= k && k < n) { Owned<int>(array_shift<int>(p,k)) };
+                  ^
+./src/examples/swap_array.c:7:18: warning: 'each' expects a 'u64', but 'k' with type 'i32' was provided. This will become an error in the future.
+    ensures take a2 = each(i32 k; 0i32 <= k && k < n) { Owned<int>(array_shift<int>(p,k)) };
+                 ^
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&i0' with type 'i32' was provided. This will become an error in the future.
+
+other location (Cn__Compile.UsingLoads.handle.load)  warning: 'extract' expects a 'u64', but 'read_&j0' with type 'i32' was provided. This will become an error in the future.
+
+[1/1]: swap_array -- pass

--- a/src/examples/transpose.broken.c.cvc5
+++ b/src/examples/transpose.broken.c.cvc5
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: transpose -- fail
+./src/examples/transpose.broken.c:12:7: error: Unprovable constraint
+  /*@ assert(false); @*/
+      ^~~~~~~~~~~~~~ 
+Constraint from ./src/examples/transpose.broken.c:12:7:
+  /*@ assert(false); @*/
+      ^~~~~~~~~~~~~~ 
+State file: file:///tmp/state__transpose.broken.c__transpose.html

--- a/src/examples/transpose.broken.c.z3
+++ b/src/examples/transpose.broken.c.z3
@@ -1,0 +1,9 @@
+return code: 1
+[1/1]: transpose -- fail
+./src/examples/transpose.broken.c:12:7: error: Unprovable constraint
+  /*@ assert(false); @*/
+      ^~~~~~~~~~~~~~ 
+Constraint from ./src/examples/transpose.broken.c:12:7:
+  /*@ assert(false); @*/
+      ^~~~~~~~~~~~~~ 
+State file: file:///tmp/state__transpose.broken.c__transpose.html

--- a/src/examples/transpose.c.cvc5
+++ b/src/examples/transpose.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: transpose -- pass

--- a/src/examples/transpose.c.z3
+++ b/src/examples/transpose.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: transpose -- pass

--- a/src/examples/transpose2.c.cvc5
+++ b/src/examples/transpose2.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: swap -- pass
+[2/2]: transpose2 -- pass

--- a/src/examples/transpose2.c.z3
+++ b/src/examples/transpose2.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: swap -- pass
+[2/2]: transpose2 -- pass

--- a/src/examples/zero.c.cvc5
+++ b/src/examples/zero.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: zero -- pass

--- a/src/examples/zero.c.z3
+++ b/src/examples/zero.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: zero -- pass

--- a/src/underconstruction/bst/contains.c.cvc5
+++ b/src/underconstruction/bst/contains.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_containsValue -- pass

--- a/src/underconstruction/bst/contains.c.z3
+++ b/src/underconstruction/bst/contains.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_containsValue -- pass

--- a/src/underconstruction/bst/copy.c.cvc5
+++ b/src/underconstruction/bst/copy.c.cvc5
@@ -1,0 +1,1 @@
+TIMEOUT

--- a/src/underconstruction/bst/copy.c.z3
+++ b/src/underconstruction/bst/copy.c.z3
@@ -1,0 +1,6 @@
+return code: 0
+[1/5]: node_nil -- pass
+[2/5]: node_cons_left -- pass
+[3/5]: node_cons_right -- pass
+[4/5]: node_cons_both -- pass
+[5/5]: node_copy -- pass

--- a/src/underconstruction/bst/create_node.c.cvc5
+++ b/src/underconstruction/bst/create_node.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_create_node -- pass

--- a/src/underconstruction/bst/create_node.c.z3
+++ b/src/underconstruction/bst/create_node.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_create_node -- pass

--- a/src/underconstruction/bst/depth.c.cvc5
+++ b/src/underconstruction/bst/depth.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_depth -- pass

--- a/src/underconstruction/bst/depth.c.z3
+++ b/src/underconstruction/bst/depth.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_depth -- pass

--- a/src/underconstruction/bst/free.c.cvc5
+++ b/src/underconstruction/bst/free.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_free_tree -- pass

--- a/src/underconstruction/bst/free.c.z3
+++ b/src/underconstruction/bst/free.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_free_tree -- pass

--- a/src/underconstruction/bst/getter.c.cvc5
+++ b/src/underconstruction/bst/getter.c.cvc5
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: get_Tree_Data -- pass
+[2/3]: get_Tree_Left -- pass
+[3/3]: get_Tree_Right -- pass

--- a/src/underconstruction/bst/getter.c.z3
+++ b/src/underconstruction/bst/getter.c.z3
@@ -1,0 +1,4 @@
+return code: 0
+[1/3]: get_Tree_Data -- pass
+[2/3]: get_Tree_Left -- pass
+[3/3]: get_Tree_Right -- pass

--- a/src/underconstruction/bst/insert.c.cvc5
+++ b/src/underconstruction/bst/insert.c.cvc5
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: node_create_node -- pass
+[2/2]: node_insert -- pass

--- a/src/underconstruction/bst/insert.c.z3
+++ b/src/underconstruction/bst/insert.c.z3
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: node_create_node -- pass
+[2/2]: node_insert -- pass

--- a/src/underconstruction/bst/length.c.cvc5
+++ b/src/underconstruction/bst/length.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_length -- pass

--- a/src/underconstruction/bst/length.c.z3
+++ b/src/underconstruction/bst/length.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_length -- pass

--- a/src/underconstruction/bst/search.c.cvc5
+++ b/src/underconstruction/bst/search.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_search -- pass

--- a/src/underconstruction/bst/search.c.z3
+++ b/src/underconstruction/bst/search.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_search -- pass

--- a/src/underconstruction/bst/sum.c.cvc5
+++ b/src/underconstruction/bst/sum.c.cvc5
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_sum -- pass

--- a/src/underconstruction/bst/sum.c.z3
+++ b/src/underconstruction/bst/sum.c.z3
@@ -1,0 +1,2 @@
+return code: 0
+[1/1]: node_sum -- pass

--- a/z3.json
+++ b/z3.json
@@ -1,0 +1,6 @@
+{
+    "name": "z3",
+    "args": ["verify"],
+    "filter": "^(.*\\.c)$",
+    "timeout": 60
+}


### PR DESCRIPTION
Cerberus repo has a test program, `diff-prog` which supports parallelised testing with rich output capture, and an easy way to update tests by emitting diffs which can be fed to patch.

diff-prog requires a JSON file for each configuration (one for Z3, another for CVC5) and a bank of expected outputs, so this commit adds both of those.