### PR TITLE
build: create and properly include exercises.zip by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ check: check-tutorial check-archive
 ##############################################################################
 # Tutorial document
 
-tutorial: exercises mkdocs.yml $(shell find docs -type f)
+tutorial: exercises docs/exercises.zip mkdocs.yml $(shell find docs -type f)
 	mkdocs build --strict
 
-serve: exercises mkdocs.yml $(shell find docs -type f)
+serve: exercises docs/exercises.zip mkdocs.yml $(shell find docs -type f)
 	mkdocs serve
 
 ##############################################################################

--- a/docs/getting-started/tutorials/README.md
+++ b/docs/getting-started/tutorials/README.md
@@ -13,7 +13,8 @@ elaborate separation logic specifications of data structures.
 ## Source files
 
 The source files for all the exercises and examples below can be downloaded
-from [here](link:exercises.zip).
+from [here](../../exercises.zip).
+<!-- Note: `../../exercises.zip` is meant to be created via `make` -->
 
 ## Tutorials
 


### PR DESCRIPTION
It seems like the exclusion of `exercises.zip` in the built and deployed tutorial was an accidental casualty of #80 (@thatplguy, does that seem plausible?). This should ensure that it gets created and uploaded in the normal course of deploying the tutorial to the web.