### PR TITLE
Include workaround header in check-archive calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,12 @@ WORKING_AUX=$(patsubst src/exercises/%, docs/solutions/%, $(WORKING))
 ##############################################################################
 # Check that the examples all run correctly
 
-CN_PATH?=cn verify $(CNWAR)
+CN_PATH?=cn verify
+CN_PATH+=$(CNWAR)
 
 check-archive:
 	@echo Check archive examples
-	@$(MAKEFILE_DIR)/src/example-archive/check-all.sh "$(CN_PATH)"
+	$(V)$(MAKEFILE_DIR)/src/example-archive/check-all.sh "$(CN_PATH)"
 
 check: exercises check-archive
 

--- a/src/exercises/cn_wars.h
+++ b/src/exercises/cn_wars.h
@@ -2,5 +2,6 @@
 #define CN_WARS_H_
 
 #define __attribute__(...)
+#define double long
 
 #endif // CN_WARS_H_


### PR DESCRIPTION
cn actually updates CN_PATH which broke its CI