### PR TITLE
Remove array_crash_2.c

### DIFF
--- a/.github/workflows/run-cn-examples.yml
+++ b/.github/workflows/run-cn-examples.yml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         version: [4.14.1]
     
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
-      with:  
+      with:
         repository: rems-project/cn
 
     - name: System dependencies (ubuntu)
@@ -43,7 +43,7 @@ jobs:
         opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam install --deps-only --yes ./cn.opam
+        opam install --deps-only --yes ./cn.opam z3
     
     - name: Save OPAM cache
       uses: actions/cache/save@v4
@@ -56,7 +56,7 @@ jobs:
       uses: robinraju/release-downloader@v1
       with:
         repository: cvc5/cvc5
-        tag: cvc5-1.2.0
+        tag: cvc5-1.3.0
         fileName: cvc5-Linux-x86_64-static.zip
 
     - name: Unzip and install cvc5
@@ -74,11 +74,11 @@ jobs:
 
     - name: Checkout cn-tutorial
       uses: actions/checkout@v4
-      with: 
+      with:
         path: cn-tutorial
 
     - name: Run CN Tutorial CI tests
       run: |
         opam switch ${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
-        USE_OPAM='' tests/run-cn-tutorial-ci.sh cn-tutorial
+        tests/run-cn-tutorial-ci.sh cn-tutorial

--- a/src/example-archive/simple-examples/broken/error-crash/array_crash_2.c
+++ b/src/example-archive/simple-examples/broken/error-crash/array_crash_2.c
@@ -1,4 +1,0 @@
-// Examples of failed array initialization. 
-// See: https://github.com/rems-project/cerberus/issues/253
-
-void a() { ({}); }


### PR DESCRIPTION
rems-project/cerberus@43acbe7 added support for expression statements, meaning that (the erroneously named) array_crash_2.c now passes the parsing by Cerberus. Hence this commit deletes it; it will be re-added in a later commit once the CN commit which bumps the Cerberus version past the above commit is merged in.